### PR TITLE
Feature Implement CI\CD

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -43,7 +43,7 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: Publish Artifact 'orchestrator-powershell'
   inputs:
-    PathtoPublish: '$(ArtifactsOutputPath)'
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
     ArtifactName: 'orchestrator-powershell'
 
 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,7 +47,7 @@ steps:
   displayName: NuGet pack
   inputs:
     command: pack
-    packagesToPack: '**/*.csproj;!**\*.Tests.csproj'
+    packagesToPack: '**\Output\$(BuildConfiguration)\*;!**\Output\$(BuildConfiguration)\.Tests.'
 
 - task: PublishBuildArtifacts@1
   displayName: Publish Artifact 'orchestrator-powershell'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,12 +47,13 @@ steps:
   displayName: NuGet pack
   inputs:
     command: pack
-    packagesToPack: '**/*.csproj;!**\*.Tests.csproj'
+    versioningScheme: byBuildNumber
+    packagesToPack: "$(Build.SourcesDirectory)\\UiPath.PowerShell.nuspec"
 
 - task: PublishBuildArtifacts@1
-  displayName: Publish Artifact 'orchestrator-powershell'
+  displayName: Publish Artifact Setup
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: 'orchestrator-powershell'
+    PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+    ArtifactName: "Setup"
 
 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,6 +1,5 @@
 queue:
   name: Hosted VS2017
-  condition: succeeded()
   demands: 
   - npm
   - msbuild

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,0 +1,57 @@
+queue:
+  name: Hosted VS2017
+  condition: succeeded()
+  demands: 
+  - npm
+  - msbuild
+  - visualstudio
+  - vstest
+
+variables:
+  Solution: "UiPath.Orchestrator.Powershell.sln"
+  BuildConfiguration: "Release"
+  BuildPlatform: "Any CPU"
+
+steps:
+- task: NuGetToolInstaller@0
+  displayName: Use NuGet 4.3.0
+
+- task: Npm@1
+  displayName: NPM install autorest
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'install -g autorest'
+
+- task: NuGetCommand@2
+  displayName: NuGet restore
+  inputs:
+    restoreSolution: "$(Solution)"
+    
+- task: VSBuild@1
+  displayName: Build solution
+  inputs:
+    solution: "$(Solution)"
+
+- task: VSTest@2
+  displayName: "Run unit tests"
+  inputs:
+    testAssemblyVer2: |
+          **\$(BuildConfiguration)\*test*.dll
+          !**\obj\**
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+
+- task: NuGetCommand@2
+  displayName: NuGet pack
+  inputs:
+    command: pack
+    packagesToPack: '**/*.csproj;!**\*.Tests.csproj'
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish Artifact 'orchestrator-powershell'
+  inputs:
+    PathtoPublish: '$(ArtifactsOutputPath)'
+    ArtifactName: 'orchestrator-powershell'
+
+

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -31,8 +31,17 @@ steps:
   displayName: Build solution
   inputs:
     solution: '$(Solution)'
+    msbuildArgs: '/Revision=$(Build.BuildId)'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
+
+- task: PowerShell@1
+  displayName: "Update Build Number"
+  inputs:
+    scriptType: "inlineScript"
+    inlineScript: |
+      $buildNumber = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("$($ENV:BUILD_SOURCESDIRECTORY)\Output\$($ENV:BUILDCONFIGURATION)\UiPath.PowerShell.dll").ProductVersion
+      Write-Host "##vso[build.updatebuildnumber]$buildNumber"
 
 - task: NuGetCommand@2
   displayName: NuGet pack

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,7 +47,7 @@ steps:
   displayName: NuGet pack
   inputs:
     command: pack
-    packagesToPack: '**\Output\$(BuildConfiguration)\*;!**\Output\$(BuildConfiguration)\.Tests.'
+    packagesToPack: '**/*.csproj;!**\*.Tests.csproj'
 
 - task: PublishBuildArtifacts@1
   displayName: Publish Artifact 'orchestrator-powershell'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -34,15 +34,6 @@ steps:
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 
-- task: VSTest@2
-  displayName: "Run unit tests"
-  inputs:
-    testAssemblyVer2: |
-          **\$(BuildConfiguration)\*test*.dll
-          !**\obj\**
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
-
 - task: NuGetCommand@2
   displayName: NuGet pack
   inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -31,7 +31,7 @@ steps:
   displayName: Build solution
   inputs:
     solution: '$(Solution)'
-    msbuildArgs: '/Revision=$(Build.BuildId)'
+    msbuildArgs: '/p:Revision=$(Build.BuildId)'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -30,7 +30,9 @@ steps:
 - task: VSBuild@1
   displayName: Build solution
   inputs:
-    solution: "$(Solution)"
+    solution: '$(Solution)'
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
 
 - task: VSTest@2
   displayName: "Run unit tests"

--- a/UiPath.PowerShell.Tests/UiPath.PowerShell.Tests.csproj
+++ b/UiPath.PowerShell.Tests/UiPath.PowerShell.Tests.csproj
@@ -24,7 +24,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\Output\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -32,7 +32,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\Output\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -103,6 +103,12 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />
   </Target>
   <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
+  <Target Name="BeforeBuild" Condition="'$(Revision)' != '' ">
+    <FileUpdate Files="..\properties\GlobalAssemblyInfo.cs" Regex="(?&lt;=AssemblyVersion\(&quot;\d+\.\d+\.\d+\.)(\*)" ReplacementText="$(Revision)" />
+  </Target>
+  <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
 </Project>

--- a/UiPath.PowerShell.Tests/packages.config
+++ b/UiPath.PowerShell.Tests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.10" targetFramework="net461" />
+  <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />

--- a/UiPath.PowerShell.nuspec
+++ b/UiPath.PowerShell.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>UiPath.PowerShell</id>
+    <version>$version$</version>
+    <title>UiPath.PowerShell</title>
+    <authors>UiPath</authors>
+    <owners>UiPath</owners>
+    <licenseUrl>https://github.com/UiPath/orchestrator-powershell/blob/master/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/uipath/orchestrator-powershell</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <developmentDependency>false</developmentDependency>
+    <description>An easy to use PowerShell API client for UiPath Orchestrator</description>
+    <copyright>UiPath</copyright>
+    <tags>UiPath Orchestrator PowerShell API client </tags>
+  </metadata>
+  <files>
+    <file src="Output\Release\*.*" target="lib\net452" exclude="Output\Release\*.pdb" />
+  </files>
+</package>

--- a/UiPath.PowerShell/UiPath.PowerShell.csproj
+++ b/UiPath.PowerShell/UiPath.PowerShell.csproj
@@ -15,24 +15,27 @@
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
   </PropertyGroup>
+  <!--<PropertyGroup>
+    <BaseOutputPath Condition="$(SolutionDir) != ''">$(SolutionDir)Output</BaseOutputPath>  
+  </PropertyGroup>-->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\Output\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\UiPath.PowerShell.xml</DocumentationFile>
+    <DocumentationFile>..\Output\Debug\UiPath.PowerShell.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\Output\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\UiPath.PowerShell.xml</DocumentationFile>
+    <DocumentationFile>..\Output\Release\UiPath.PowerShell.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -175,5 +178,10 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\XmlDoc2CmdletDoc.0.2.9\build\XmlDoc2CmdletDoc.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\XmlDoc2CmdletDoc.0.2.9\build\XmlDoc2CmdletDoc.targets'))" />
+    <Error Condition="!Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />
   </Target>
+  <Target Name="BeforeBuild" Condition="'$(Revision)' != '' ">
+    <FileUpdate Files="..\properties\GlobalAssemblyInfo.cs" Regex="(?&lt;=AssemblyVersion\(&quot;\d+\.\d+\.\d+\.)(\*)" ReplacementText="$(Revision)" />
+  </Target>
+  <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
 </Project>

--- a/UiPath.PowerShell/packages.config
+++ b/UiPath.PowerShell/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.11" targetFramework="net452" />
+  <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net452" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net461" />
   <package id="RestSharp" version="106.2.1" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" requireReinstallation="true" />

--- a/UiPath.Web.Client/UiPath.Web.Client.csproj
+++ b/UiPath.Web.Client/UiPath.Web.Client.csproj
@@ -12,12 +12,14 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\Output\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\Output\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -76,4 +78,15 @@
       <FileWrites Include="@(AutoRestGenerated)" />
     </ItemGroup>
   </Target>
+  <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />
+  </Target>
+  <Target Name="BeforeBuild" Condition="'$(Revision)' != '' ">
+    <FileUpdate Files="..\properties\GlobalAssemblyInfo.cs" Regex="(?&lt;=AssemblyVersion\(&quot;\d+\.\d+\.\d+\.)(\*)" ReplacementText="$(Revision)" />
+  </Target>
+  <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
 </Project>

--- a/UiPath.Web.Client/packages.config
+++ b/UiPath.Web.Client/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.11" targetFramework="net452" />
+  <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net452" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net461" />
   <package id="RestSharp" version="106.2.1" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" requireReinstallation="true" />


### PR DESCRIPTION
Hi,

Based on Work Item # UI-16842, Build & Release pipelines have been created for the Orchestrator PowerShell Module.

CI is defined in the yml file, CD is not yet available through YML file.

Currently we publish the module in our own NuGet Feed, but we're planning to change the publishing towards the official PowerShell Gallery (https://www.powershellgallery.com), but this change has nothing to do with the actual code.

CI\CD pipes are under the 'Community)' VSTS Project:
CI-Orchestrator-PS-Module
CD-Orchestrator-PS-Module

Thank you,
Andrei