### PR TITLE
Support $DebugPreference with HTTP request dump

### DIFF
--- a/UiPath.PowerShell/UiPath.PowerShell.csproj
+++ b/UiPath.PowerShell/UiPath.PowerShell.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Util\HashtableExtenssions.cs" />
     <Compile Include="Util\NetworkAuthenticationCredentials.cs" />
     <Compile Include="Util\PSCredentialExtenssions.cs" />
+    <Compile Include="Util\RestVerboseTracer.cs" />
     <Compile Include="Util\SetParameterAttribute.cs" />
     <Compile Include="Util\UiPathCmdlet.cs" />
     <Compile Include="Models\Asset.cs" />

--- a/UiPath.PowerShell/Util/RestVerboseTracer.cs
+++ b/UiPath.PowerShell/Util/RestVerboseTracer.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.Rest;
+using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Net.Http;
+using System.Text;
+
+namespace UiPath.PowerShell.Util
+{
+    internal class RestVerboseTracer : IServiceClientTracingInterceptor
+    {
+        [Flags]
+        public enum ETraceFlags
+        {
+            Enabled = 0x01,
+            Headers = 0x02,
+            Content = 0x04,
+        };
+
+        private volatile StringBuilder _traces;
+        private ETraceFlags _traceFlags = 0;
+
+        public bool IsEnabled => _traceFlags.HasFlag(ETraceFlags.Enabled);
+
+
+
+        public void Configuration(string source, string name, string value)
+        {
+        }
+
+        public void EnterMethod(string invocationId, object instance, string method, IDictionary<string, object> parameters)
+        {
+
+        }
+
+        public void ExitMethod(string invocationId, object returnValue)
+        {
+        }
+
+        internal void StartTracing(ETraceFlags traceFlags)
+        {
+            _traceFlags = traceFlags;
+            if (IsEnabled)
+            {
+                _traces = new StringBuilder();
+            }
+        }
+
+        internal void Flush(PSCmdlet cmdlet)
+        {
+            if (IsEnabled)
+            {
+                var oldTraces = _traces;
+                _traces = new StringBuilder();
+                if (oldTraces.Length > 0)
+                {
+                    cmdlet.WriteVerbose(oldTraces.ToString());
+                }
+            }
+        }
+
+        internal void StopTracing()
+        {
+            _traceFlags = 0;
+            _traces = null; ;
+        }
+
+        public void Information(string message)
+        {
+            if (IsEnabled)
+            {
+                _traces.AppendLine(message);
+            }
+        }
+
+        public void ReceiveResponse(string invocationId, HttpResponseMessage response)
+        {
+            if (IsEnabled)
+            {
+                _traces.AppendLine($"HTTP response: {response.StatusCode}");
+                if (_traceFlags.HasFlag(ETraceFlags.Headers))
+                {
+                    _traces.AppendLine(response.Headers.ToString());
+                }
+                if (_traceFlags.HasFlag(ETraceFlags.Content) && null != response.Content)
+                {
+                    _traces.AppendLine(response.Content.ReadAsStringAsync().Result);
+                }
+            }
+        }
+
+        public void SendRequest(string invocationId, HttpRequestMessage request)
+        {
+            if (IsEnabled)
+            {
+                _traces.AppendLine($"HTTP request: {request.Method} {request.RequestUri}");
+                if (_traceFlags.HasFlag(ETraceFlags.Headers))
+                {
+                    _traces.AppendLine(request.Headers.ToString());
+                }
+                if (_traceFlags.HasFlag(ETraceFlags.Content) && null != request.Content)
+                {
+                    _traces.AppendLine(request.Content.ReadAsStringAsync().Result);
+                }
+            }
+
+        }
+
+        public void TraceError(string invocationId, Exception exception)
+        {
+            if (IsEnabled)
+            {
+                _traces.AppendLine($"HTTP exception: {exception.GetType().Name}:{exception.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
 - Honor `$VerbosePReference`, not only `-Verbose`
 - Print HTTP request URI and response status on Verbose
 - Honor `$DebugPreference`
 - Dump HTTP request and response headers/content