### PR TITLE
Fix Roslyn build version * crap

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -31,7 +31,7 @@ steps:
   displayName: Build solution
   inputs:
     solution: '$(Solution)'
-    msbuildArgs: '/p:Revision=$(Build.BuildId)'
+    msbuildArgs: '/p:Revision=$(Build.BuildId) /p:UseSharedCompilation=False'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 

--- a/UiPath.PowerShell.Tests/UiPath.PowerShell.Tests.csproj
+++ b/UiPath.PowerShell.Tests/UiPath.PowerShell.Tests.csproj
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+      <Deterministic>False</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -120,8 +121,5 @@
   </Target>
   <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
   <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
-  <Target Name="BeforeBuild" Condition="'$(Revision)' != '' ">
-    <FileUpdate Files="..\properties\GlobalAssemblyInfo.cs" Regex="(?&lt;=AssemblyVersion\(&quot;\d+\.\d+\.\d+\.)(\*)" ReplacementText="$(Revision)" />
-  </Target>
   <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
 </Project>

--- a/UiPath.PowerShell/UiPath.PowerShell.csproj
+++ b/UiPath.PowerShell/UiPath.PowerShell.csproj
@@ -14,6 +14,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+      <Deterministic>False</Deterministic>
   </PropertyGroup>
   <!--<PropertyGroup>
     <BaseOutputPath Condition="$(SolutionDir) != ''">$(SolutionDir)Output</BaseOutputPath>  
@@ -210,9 +211,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\XmlDoc2CmdletDoc.0.2.9\build\XmlDoc2CmdletDoc.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\XmlDoc2CmdletDoc.0.2.9\build\XmlDoc2CmdletDoc.targets'))" />
     <Error Condition="!Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />
-  </Target>
-  <Target Name="BeforeBuild" Condition="'$(Revision)' != '' ">
-    <FileUpdate Files="..\properties\GlobalAssemblyInfo.cs" Regex="(?&lt;=AssemblyVersion\(&quot;\d+\.\d+\.\d+\.)(\*)" ReplacementText="$(Revision)" />
   </Target>
   <UsingTask TaskName="GetFileVersion" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
     <ParameterGroup>

--- a/UiPath.Web.Client/UiPath.Web.Client.csproj
+++ b/UiPath.Web.Client/UiPath.Web.Client.csproj
@@ -14,6 +14,7 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+      <Deterministic>False</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,8 +57,10 @@
   <ItemGroup>
     <Compile Include="IUiPathWebApi.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="..\Properties\GlobalAssemblyInfo.cs">
+    <Compile Include="$(SolutionDir)Properties\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
+      <AutoGen>True</AutoGen>
+      <Visible>True</Visible>
     </Compile>
     <Compile Include="UiPathWebApi.cs" />
   </ItemGroup>
@@ -95,14 +98,21 @@
     </ItemGroup>
   </Target>
   <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+  <Target Name="EnsureNuGetPackageBuildImports">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />
   </Target>
-  <Target Name="BeforeBuild" Condition="'$(Revision)' != '' ">
-    <FileUpdate Files="..\properties\GlobalAssemblyInfo.cs" Regex="(?&lt;=AssemblyVersion\(&quot;\d+\.\d+\.\d+\.)(\*)" ReplacementText="$(Revision)" />
+  <Target Name="ApplyRevision"
+          BeforeTargets="PrepareForBuild"
+          Condition="'$(Revision)' != '' " 
+          Outputs="$(SolutionDir)\properties\GlobalAssemblyInfo.cs">
+    <!-- This is only needed once per VSTS solution build, and Web.Client is the first built project (because of dependency graph) -->
+    <Error Condition="$(Revision) &gt; 65535" Text="The Revision number $(Revision) cannot exceed 65535"/>
+    <Message Text="Replace GlobalAssemblyInfo.cs AssemblyVersion revision with: $(Revision)"/>
+    <FileUpdate Files="$(SolutionDir)\properties\GlobalAssemblyInfo.cs" Regex="(?&lt;=AssemblyVersion\(&quot;\d+\.\d+\.\d+\.)(\*)" ReplacementText="$(Revision)" />
+    <Exec Command="type $(SolutionDir)properties\GlobalAssemblyInfo.cs"/>
   </Target>
   <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
 </Project>


### PR DESCRIPTION
https://stackoverflow.com/a/46985624/105929

```
Properties\GlobalAssemblyInfo.cs(14,28): Error CS7034: The specified version string does not conform to the required format - major[.minor[.build[.revision]]]
```