### PR TITLE
Handle Add-User -Domain

### DIFF
--- a/UiPath.PowerShell/Cmdlets/AddUser.cs
+++ b/UiPath.PowerShell/Cmdlets/AddUser.cs
@@ -12,17 +12,20 @@ namespace UiPath.PowerShell.Cmdlets
     [Cmdlet(VerbsCommon.Add, Nouns.User)]
     public class AddUser : AuthenticatedCmdlet
     {
-        [Parameter(Mandatory = true)]
+        private const string UserPwdSet = "UserPwdSet";
+        private const string WindowsSet = "WindowsSet";
+
+        [Parameter(Mandatory = true, Position = 0)]
         public string Username { get; private set; }
 
         //[Credential]
-        [Parameter]
+        [Parameter(Mandatory = true, ParameterSetName =UserPwdSet)]
         public string Password { get; private set; }
 
-        [Parameter]
+        [Parameter(ParameterSetName =UserPwdSet)]
         public string Name { get; private set; }
 
-        [Parameter]
+        [Parameter(ParameterSetName = UserPwdSet)]
         public string Surname { get; private set; }
 
         [Parameter]
@@ -34,20 +37,39 @@ namespace UiPath.PowerShell.Cmdlets
         [Parameter]
         public List<long> OrganizationUnitIds { get; set; }
 
-        [ValidateEnum(typeof(UserDtoType))]
-        [Parameter]
-        public string Type { get; set; }
+        [Parameter(ParameterSetName = WindowsSet)]
+        public string Domain { get; private set; }
 
         protected override void ProcessRecord()
         {
+            if (Username.Contains('\\'))
+            {
+                var parts = Username.Split('\\');
+                if (parts.Length != 2)
+                {
+                    throw new Exception($"The NT username {Username} can only contain one '\\' delimitator.");
+                }
+
+                if (string.IsNullOrWhiteSpace(Domain))
+                {
+                    Domain = parts[0];
+                }
+
+                if (0 != string.Compare(Domain, parts[0], true))
+                {
+                    throw new Exception($"The NT username {Username} must match the domain {Domain}.");
+                }
+            }
+
             var user = new UserDto
             {
                 UserName = Username,
                 Password = Password,
+                Domain = Domain,
                 Name = Name,
                 Surname = Surname,
                 EmailAddress = EmailAddress,
-                RolesList = RolesList,
+                RolesList = RolesList ?? new List<string>(),
                 OrganizationUnits = OrganizationUnitIds?.Select(
                     id => new OrganizationUnitDto
                     {
@@ -55,11 +77,6 @@ namespace UiPath.PowerShell.Cmdlets
                         DisplayName = id.ToString() // The DisplayName cannot be null or empty string, but the actual value is irelevant
                     }).ToList()
             };
-            UserDtoType type;
-            if (Enum.TryParse<UserDtoType>(Type, out type))
-            {
-                user.Type = type;
-            }
             var dto = HandleHttpOperationException(() => Api.Users.Post(user));
             WriteObject(User.FromDto(dto));
         }

--- a/docs/Add-UiPathUser.md
+++ b/docs/Add-UiPathUser.md
@@ -7,9 +7,11 @@ SYNOPSIS
     
     
 SYNTAX
-    Add-UiPathUser -Username <string> [-AuthToken <AuthToken>] [-EmailAddress <string>] [-Name <string>] 
-    [-OrganizationUnitIds <List`1>] [-Password <string>] [-RolesList <List`1>] [-Surname <string>] [-Type <string>] 
-    [<CommonParameters>]
+    Add-UiPathUser [-Username] <string> -Password <string> [-AuthToken <AuthToken>] [-EmailAddress <string>] [-Name 
+    <string>] [-OrganizationUnitIds <List`1>] [-RolesList <List`1>] [-Surname <string>] [<CommonParameters>]
+    
+    Add-UiPathUser [-Username] <string> [-AuthToken <AuthToken>] [-Domain <string>] [-EmailAddress <string>] 
+    [-OrganizationUnitIds <List`1>] [-RolesList <List`1>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -19,14 +21,14 @@ PARAMETERS
     -Username <string>
         
         Required?                    true
-        Position?                    named
+        Position?                    0
         Default value                
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
     -Password <string>
         
-        Required?                    false
+        Required?                    true
         Position?                    named
         Default value                
         Accept pipeline input?       false
@@ -72,7 +74,7 @@ PARAMETERS
         Accept pipeline input?       false
         Accept wildcard characters?  false
         
-    -Type <string>
+    -Domain <string>
         
         Required?                    false
         Position?                    named


### PR DESCRIPTION
Orchestrator 18.3 introduced the Login provider behavior and as a side
effect forgot to handle domain\user usernames. The DTO Domain
**must** be set for the Windows provider to be recognized.

This fix adds an optional `-Domain` to `Add-UiPathUser` and also logic
to handle the `domain\user` form and extract the domain automatically
(this matches the Orchestrator UI behavior).

Fixes #35