### PR TITLE
Auth token will not be written to output

### DIFF
--- a/UiPath.PowerShell/Cmdlets/GetAuthToken.cs
+++ b/UiPath.PowerShell/Cmdlets/GetAuthToken.cs
@@ -114,6 +114,8 @@ namespace UiPath.PowerShell.Cmdlets
                 {
                     AuthenticatedCmdlet.SetAuthToken(authToken);
                 }
+
+                WriteObject(authToken);
             }
         }
 

--- a/UiPath.PowerShell/Cmdlets/GetAuthToken.cs
+++ b/UiPath.PowerShell/Cmdlets/GetAuthToken.cs
@@ -114,8 +114,6 @@ namespace UiPath.PowerShell.Cmdlets
                 {
                     AuthenticatedCmdlet.SetAuthToken(authToken);
                 }
-
-                WriteObject(authToken);
             }
         }
 

--- a/UiPath.PowerShell/Models/AuthToken.cs
+++ b/UiPath.PowerShell/Models/AuthToken.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Management.Automation;
 
 namespace UiPath.PowerShell.Models
 {
@@ -9,6 +10,7 @@ namespace UiPath.PowerShell.Models
     {
         public string URL { get; internal set; }
 
+        [Hidden]
         public string Token { get; internal set; }
 
         public bool WindowsCredentials { get; internal set; }


### PR DESCRIPTION
For security reasons lets not write auth token to output unless is requested using -CurrentSession parameter