### PR TITLE
Add Lock-UiPathUser & Unlock-UiPathUser cmdlets [UI-21736]

### DIFF
--- a/Examples/Lock-UiPathInactiveUsers.ps1
+++ b/Examples/Lock-UiPathInactiveUsers.ps1
@@ -1,0 +1,55 @@
+﻿<#
+    .SYNOPSIS
+        Mark as inactive users in Orchestrator with no activity in last X days
+    .DESCRIPTION
+        You must run this script as an user that has the privilege to edit users. This privilege can be delegated to you by a domain administrator.
+        You should first import the UiPath.PowerShell module and authenticate yourself with your Orchestrator using Get-UiPathAuthToken before running this script.
+        Users with Administrator roles are skipped
+    .PARAMETER Days
+        Number of days of inactivity. Default is 90 days
+#>
+param(
+    [Parameter()] [int]$Days = 90
+)
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $datetime = (Get-Date).ToUniversalTime().AddDays(-$Days)
+    Write-Verbose "Last activity acceptead date is $datetime"
+
+    # Discover all active users
+    Write-Verbose "Get-UiPathUser -Type User -IsActive $true | where {$_.Username -ne 'Admin'}"
+
+    $allUsers = Get-UiPathUser -Type User -IsActive $true | where {$_.Username -ne "Admin"}
+
+    foreach ($user in $allUsers) {
+        if ($user.RolesList -contains 'Administrator') {
+            Write-Verbose "Skipping user $($user.Name). Reason: Administrator"
+        }
+        else {
+            $lastActivityDate = $user.LastLoginTime
+            if ($null -eq $lastActivityDate) {
+                $lastActivityDate = $user.CreationTime
+            }
+
+            if ($datetime -gt $lastActivityDate) {
+
+                Write-Verbose "Lock-UiPathUser -Id $($user.Id)"
+                Lock-UiPathUser -Id $user.Id
+            }`
+            else {
+                Write-Verbose "Skipping user $($user.Name). Reason: Active in the last $Days Days"
+            }
+        }
+    }
+}
+catch {
+    $e = $_.Exception
+    $klass = $e.GetType().Name
+    $line = $_.InvocationInfo.ScriptLineNumber
+    $script = $_.InvocationInfo.ScriptName
+    $msg = $e.Message
+
+    Write-Error "$klass $msg ($script $line)"
+}

--- a/UiPath.Orchestrator.Powershell.sln
+++ b/UiPath.Orchestrator.Powershell.sln
@@ -25,6 +25,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{BBCF7871-E3BE-491E-B522-8616CFACB4E8}"
 	ProjectSection(SolutionItems) = preProject
 		Examples\Get-UiPathPackageDependencies.ps1 = Examples\Get-UiPathPackageDependencies.ps1
+		Examples\Lock-UiPathInactiveUsers.ps1 = Examples\Lock-UiPathInactiveUsers.ps1
 		Examples\Sync-UiPathADUsers.ps1 = Examples\Sync-UiPathADUsers.ps1
 		Examples\Update-UiPathADRobotPasswords.ps1 = Examples\Update-UiPathADRobotPasswords.ps1
 	EndProjectSection

--- a/UiPath.PowerShell/Cmdlets/LockUser.cs
+++ b/UiPath.PowerShell/Cmdlets/LockUser.cs
@@ -1,0 +1,14 @@
+﻿using System.Management.Automation;
+using UiPath.PowerShell.Util;
+using UiPath.Web.Client20181;
+using UiPath.Web.Client20181.Models;
+
+namespace UiPath.PowerShell.Cmdlets
+{
+    [Cmdlet(VerbsCommon.Lock, Nouns.User)]
+    public class LockUser : UserCmdlet
+    {
+        protected override void ProcessRecord(long userId) =>
+            Api.Users.SetActiveById(userId, new SetUserActiveParameters(false));
+    }
+}

--- a/UiPath.PowerShell/Cmdlets/UnlockUser.cs
+++ b/UiPath.PowerShell/Cmdlets/UnlockUser.cs
@@ -1,0 +1,14 @@
+﻿using System.Management.Automation;
+using UiPath.PowerShell.Util;
+using UiPath.Web.Client20181;
+using UiPath.Web.Client20181.Models;
+
+namespace UiPath.PowerShell.Cmdlets
+{
+    [Cmdlet(VerbsCommon.Unlock, Nouns.User)]
+    public class UnlockUser : UserCmdlet
+    {
+        protected override void ProcessRecord(long userId) =>
+            Api.Users.SetActiveById(userId, new SetUserActiveParameters(true));
+    }
+}

--- a/UiPath.PowerShell/UiPath.PowerShell.csproj
+++ b/UiPath.PowerShell/UiPath.PowerShell.csproj
@@ -51,6 +51,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Cmdlets\UnlockUser.cs" />
+    <Compile Include="Cmdlets\LockUser.cs" />
+    <Compile Include="Util\UserCmdlet.cs" />
     <Compile Include="Util\BindingResolver.cs" />
     <Compile Include="Cmdlets\AddAsset.cs" />
     <Compile Include="Cmdlets\AddEnvironment.cs" />

--- a/UiPath.PowerShell/Util/UserCmdlet.cs
+++ b/UiPath.PowerShell/Util/UserCmdlet.cs
@@ -1,0 +1,21 @@
+﻿using System.Management.Automation;
+using UiPath.PowerShell.Models;
+
+namespace UiPath.PowerShell.Util
+{
+    public abstract class UserCmdlet : AuthenticatedCmdlet
+    {
+        [ValidateNotNull]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Id")]
+        public long? Id { get; set; }
+
+        [ValidateNotNull]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "User", ValueFromPipeline = true)]
+        public User User { get; set; }
+
+        protected abstract void ProcessRecord(long userId);
+
+        protected override void ProcessRecord() =>
+            HandleHttpOperationException(() => ProcessRecord(User?.Id ?? Id.GetValueOrDefault()));
+    }
+}

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -49,6 +49,7 @@
 - [Get-UiPathUser](Get-UiPathUser.md)
 - [Get-UiPathWebhook](Get-UiPathWebhook.md)
 - [Grant-UiPathRolePermission](Grant-UiPathRolePermission.md)
+- [Lock-UiPathUser](Lock-UiPathUser.md)
 - [New-UiPathAssetRobotValue](New-UiPathAssetRobotValue.md)
 - [Register-UiPathLicense](Register-UiPathLicense.md)
 - [Remove-UiPathAsset](Remove-UiPathAsset.md)
@@ -71,4 +72,5 @@
 - [Set-UiPathAuthToken](Set-UiPathAuthToken.md)
 - [Start-UiPathJob](Start-UiPathJob.md)
 - [Stop-UiPathJob](Stop-UiPathJob.md)
+- [Unlock-UiPathUser](Unlock-UiPathUser.md)
 - [Update-UiPathProcess](Update-UiPathProcess.md)

--- a/docs/Lock-UiPathUser.md
+++ b/docs/Lock-UiPathUser.md
@@ -1,0 +1,60 @@
+﻿```PowerShell
+
+NAME
+    Lock-UiPathUser
+    
+SYNOPSIS
+    
+    
+SYNTAX
+    Lock-UiPathUser [-Id] <long> [-AuthToken <AuthToken>] [<CommonParameters>]
+    
+    Lock-UiPathUser [-User] <User> [-AuthToken <AuthToken>] [<CommonParameters>]
+    
+    
+DESCRIPTION
+    
+
+PARAMETERS
+    -Id <long>
+        
+        Required?                    true
+        Position?                    0
+        Default value                
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -User <User>
+        
+        Required?                    true
+        Position?                    0
+        Default value                
+        Accept pipeline input?       true (ByValue)
+        Accept wildcard characters?  false
+        
+    -AuthToken <AuthToken>
+        
+        Required?                    false
+        Position?                    named
+        Default value                
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see 
+        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216). 
+    
+INPUTS
+    UiPath.PowerShell.Models.User
+    
+    
+OUTPUTS
+    
+    
+RELATED LINKS
+
+
+
+```

--- a/docs/Unlock-UiPathUser.md
+++ b/docs/Unlock-UiPathUser.md
@@ -1,0 +1,60 @@
+﻿```PowerShell
+
+NAME
+    Unlock-UiPathUser
+    
+SYNOPSIS
+    
+    
+SYNTAX
+    Unlock-UiPathUser [-Id] <long> [-AuthToken <AuthToken>] [<CommonParameters>]
+    
+    Unlock-UiPathUser [-User] <User> [-AuthToken <AuthToken>] [<CommonParameters>]
+    
+    
+DESCRIPTION
+    
+
+PARAMETERS
+    -Id <long>
+        
+        Required?                    true
+        Position?                    0
+        Default value                
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -User <User>
+        
+        Required?                    true
+        Position?                    0
+        Default value                
+        Accept pipeline input?       true (ByValue)
+        Accept wildcard characters?  false
+        
+    -AuthToken <AuthToken>
+        
+        Required?                    false
+        Position?                    named
+        Default value                
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see 
+        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216). 
+    
+INPUTS
+    UiPath.PowerShell.Models.User
+    
+    
+OUTPUTS
+    
+    
+RELATED LINKS
+
+
+
+```


### PR DESCRIPTION
Adding cmdlets for Locking/Unlocking users
- `Lock-UiPathUser` marks a user as inactive
- `Unlock-UiPathUser` marks a user as active 

In Examples `Lock-UiPathInactiveUsers.ps1  [-Days] <int>` will mark all users, except administrators, with no activity in the last X Days as inactive 

[UI-21736](https://uipath.atlassian.net/browse/UI-21736)