### PR TITLE
Update Sync-UiPathADUsers to include child domains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+# Visual Studio Code cache/options directory
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/UiPath.PowerShell/Cmdlets/AddUser.cs
+++ b/UiPath.PowerShell/Cmdlets/AddUser.cs
@@ -54,11 +54,6 @@ namespace UiPath.PowerShell.Cmdlets
                 {
                     Domain = parts[0];
                 }
-
-                if (0 != string.Compare(Domain, parts[0], true))
-                {
-                    throw new Exception($"The NT username {Username} must match the domain {Domain}.");
-                }
             }
 
             var user = new UserDto


### PR DESCRIPTION
to include child domain names (-AllowedDomainNames parameter)

Now domain name is recreated from group/user distinguishedName
Add-UiPathUser is called without Name & Surname for Windows users