### PR TITLE
Add TypeConverter to the model types

### DIFF
--- a/UiPath.PowerShell/Models/Asset.cs
+++ b/UiPath.PowerShell/Models/Asset.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Management.Automation;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
@@ -8,6 +10,7 @@ namespace UiPath.PowerShell.Models
     /// <summary>
     /// <para type="description">An UiPath Orchestrator asset</para>
     /// </summary>
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Asset
     {
         public long Id { get; private set; }

--- a/UiPath.PowerShell/Models/AssetRobotValue.cs
+++ b/UiPath.PowerShell/Models/AssetRobotValue.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections;
+using System.ComponentModel;
 using System.Management.Automation;
 using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class AssetRobotValue
     {
         public long RobotId { get; internal set; }

--- a/UiPath.PowerShell/Models/AuthToken.cs
+++ b/UiPath.PowerShell/Models/AuthToken.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Management.Automation;
+using UiPath.PowerShell.Util;
 
 namespace UiPath.PowerShell.Models
 {
     /// <summary>
     /// The Token needed to authenticate UiPath cmdlets
     /// </summary>
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class AuthToken
     {
         public string URL { get; internal set; }

--- a/UiPath.PowerShell/Models/Environment.cs
+++ b/UiPath.PowerShell/Models/Environment.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Environment
     {
         public long Id { get; private set; }

--- a/UiPath.PowerShell/Models/Job.cs
+++ b/UiPath.PowerShell/Models/Job.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.ComponentModel;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Job
     {
         public long Id { get; private set; }

--- a/UiPath.PowerShell/Models/Library.cs
+++ b/UiPath.PowerShell/Models/Library.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.ComponentModel;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20183.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Library
     {
         public string Id { get; private set; }

--- a/UiPath.PowerShell/Models/License.cs
+++ b/UiPath.PowerShell/Models/License.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.ComponentModel;
+using UiPath.PowerShell.Util;
 using License20181Dto = UiPath.Web.Client20181.Models.LicenseDto;
 using License20183Dto = UiPath.Web.Client20183.Models.LicenseDto;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class License
     {
         public long? Id { get; private set; }

--- a/UiPath.PowerShell/Models/Machine.cs
+++ b/UiPath.PowerShell/Models/Machine.cs
@@ -1,10 +1,12 @@
-﻿using System;
+﻿using System.ComponentModel;
+using UiPath.PowerShell.Util;
 using MachineDto20182 = UiPath.Web.Client20182.Models.MachineDto;
 using MachineDto20183 = UiPath.Web.Client20183.Models.MachineDto;
 using MachineDtoType = UiPath.Web.Client20183.Models.MachineDtoType;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Machine
     {
         public long? Id { get; private set; }

--- a/UiPath.PowerShell/Models/OrganizationUnit.cs
+++ b/UiPath.PowerShell/Models/OrganizationUnit.cs
@@ -1,7 +1,10 @@
-﻿using UiPath.Web.Client20181.Models;
+﻿using System.ComponentModel;
+using UiPath.PowerShell.Util;
+using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class OrganizationUnit
     {
         public long Id { get; set; }

--- a/UiPath.PowerShell/Models/Package.cs
+++ b/UiPath.PowerShell/Models/Package.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Package
     {
         public string Id { get; private set; }

--- a/UiPath.PowerShell/Models/Permission.cs
+++ b/UiPath.PowerShell/Models/Permission.cs
@@ -1,7 +1,10 @@
-﻿using UiPath.Web.Client20181.Models;
+﻿using System.ComponentModel;
+using UiPath.PowerShell.Util;
+using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Permission
     {
         public long? Id { get; private set; }

--- a/UiPath.PowerShell/Models/Process.cs
+++ b/UiPath.PowerShell/Models/Process.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Process
     {
         public long Id { get; private set; }

--- a/UiPath.PowerShell/Models/ProcessSchedule.cs
+++ b/UiPath.PowerShell/Models/ProcessSchedule.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class ProcessSchedule
     {
         private string startProcessCronDetails;

--- a/UiPath.PowerShell/Models/QueueDefinition.cs
+++ b/UiPath.PowerShell/Models/QueueDefinition.cs
@@ -1,7 +1,10 @@
-﻿using UiPath.Web.Client20181.Models;
+﻿using System.ComponentModel;
+using UiPath.PowerShell.Util;
+using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class QueueDefinition
     {
         public long Id { get; internal set; }

--- a/UiPath.PowerShell/Models/QueueItem.cs
+++ b/UiPath.PowerShell/Models/QueueItem.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class QueueItem
     {
         public long Id { get; internal set; }

--- a/UiPath.PowerShell/Models/Robot.cs
+++ b/UiPath.PowerShell/Models/Robot.cs
@@ -6,9 +6,12 @@ using RobotDtoHostingType20183 = UiPath.Web.Client20183.Models.RobotDtoHostingTy
 using RobotDto20181 = UiPath.Web.Client20181.Models.RobotDto;
 using RobotDto20183 = UiPath.Web.Client20183.Models.RobotDto;
 using RobotDto20184 = UiPath.Web.Client20184.Models.RobotDto;
+using UiPath.PowerShell.Util;
+using System.ComponentModel;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Robot
     {
         public long Id { get; private set; }

--- a/UiPath.PowerShell/Models/Role.cs
+++ b/UiPath.PowerShell/Models/Role.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Role
     {
         public string Name { get; private set; }

--- a/UiPath.PowerShell/Models/Setting.cs
+++ b/UiPath.PowerShell/Models/Setting.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Setting
     {
         public string Name { get; private set; }

--- a/UiPath.PowerShell/Models/Tenant.cs
+++ b/UiPath.PowerShell/Models/Tenant.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Tenant
     {
         public int Id { get; private set; }

--- a/UiPath.PowerShell/Models/Timezone.cs
+++ b/UiPath.PowerShell/Models/Timezone.cs
@@ -1,7 +1,10 @@
-﻿using UiPath.Web.Client20181.Models;
+﻿using System.ComponentModel;
+using UiPath.PowerShell.Util;
+using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Timezone
     {
         public string Name { get; internal set; }

--- a/UiPath.PowerShell/Models/User.cs
+++ b/UiPath.PowerShell/Models/User.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class User
     {
         public string AuthenticationSource { get; private set; }

--- a/UiPath.PowerShell/Models/Webhook.cs
+++ b/UiPath.PowerShell/Models/Webhook.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using UiPath.PowerShell.Util;
 using UiPath.Web.Client20184.Models;
 
 namespace UiPath.PowerShell.Models
 {
+    [TypeConverter(typeof(UiPathTypeConverter))]
     public class Webhook
     {
         public string Url { get; internal set; }

--- a/UiPath.PowerShell/UiPath.PowerShell.csproj
+++ b/UiPath.PowerShell/UiPath.PowerShell.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Cmdlets\GetEnvironmentRobot.cs" />
     <Compile Include="Cmdlets\UnlockUser.cs" />
     <Compile Include="Cmdlets\LockUser.cs" />
+    <Compile Include="Util\UiPathTypeConverter.cs" />
     <Compile Include="Util\UserCmdlet.cs" />
     <Compile Include="Util\BindingResolver.cs" />
     <Compile Include="Cmdlets\AddAsset.cs" />

--- a/UiPath.PowerShell/Util/UiPathTypeConverter.cs
+++ b/UiPath.PowerShell/Util/UiPathTypeConverter.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Management.Automation;
+using System.Reflection;
+
+namespace UiPath.PowerShell.Util
+{
+    public class UiPathTypeConverter : PSTypeConverter
+    {
+        public override bool CanConvertFrom(object sourceValue, Type destinationType)
+        {
+            return destinationType.Namespace == "UiPath.PowerShell.Models" &&
+                (sourceValue is PSObject ||
+                sourceValue is Hashtable);
+        }
+
+        public override bool CanConvertTo(object sourceValue, Type destinationType)
+        {
+            return false;
+        }
+
+        public override object ConvertFrom(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase)
+        {
+            if (sourceValue is PSObject)
+            {
+                return ConvertFromPSObject((PSObject)sourceValue, destinationType);
+            }
+            else if (sourceValue is Hashtable)
+            {
+                return ConvertFromHT((Hashtable)sourceValue, destinationType);
+            }
+
+            // Huh? We said that we can only convert the types we know...
+            throw new NotImplementedException($"Need to parse: {sourceValue}");
+        }
+
+        private object ConvertFromHT(Hashtable sourceValue, Type destinationType)
+        {
+            return ConvertFromFN(destinationType, (propertyName) => sourceValue[propertyName]);
+        }
+
+        private static object ConvertFromPSObject(PSObject pso, Type destinationType)
+        {
+            return ConvertFromFN(destinationType, (propertyName) => pso.Properties[propertyName]?.Value);
+        }
+
+        private static object ConvertFromFN(Type destinationType, Func<string, object> fn)
+        {
+            var ctor = destinationType.GetConstructor(new Type[] { });
+            var instance = ctor.Invoke(new object[] { });
+
+            foreach(var p in destinationType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                var value = fn(p.Name);
+                if (value != null)
+                {
+                    if (!p.PropertyType.IsAssignableFrom(value.GetType()))
+                    {
+                        var converter = TypeDescriptor.GetConverter(p.PropertyType);
+                        value = converter.ConvertFrom(value);
+                    }
+                    p.SetValue(instance, value);
+                }
+            }
+
+            return instance;
+        }
+
+        public override object ConvertTo(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Declare a `TypeConverterAttribute` on our models (including the
AuthToken). Implement the conversion from `PSObject` and from
`Hashtable` via Reflection of public properties.

This should solve all the CodeBuild issue because variables are
serialized/deserialized and rehydration requires type conversion.

 - https://devblogs.microsoft.com/powershell/how-objects-are-sent-to-and-from-remote-sessions/

Fixes #44