### PR TITLE
Make -Password optional to Add-UiPathUser

### DIFF
--- a/UiPath.PowerShell/Cmdlets/AddUser.cs
+++ b/UiPath.PowerShell/Cmdlets/AddUser.cs
@@ -19,7 +19,7 @@ namespace UiPath.PowerShell.Cmdlets
         public string Username { get; private set; }
 
         //[Credential]
-        [Parameter(Mandatory = true, ParameterSetName =UserPwdSet)]
+        [Parameter(ParameterSetName =UserPwdSet)]
         public string Password { get; private set; }
 
         [Parameter(ParameterSetName =UserPwdSet)]


### PR DESCRIPTION
AzureAD integration allows for user w/o password in Orchestrator

Fixes #47