### PR TITLE
Cmdlets: Add RobotSettings cmdlets and 19.4.3 API

### DIFF
--- a/UiPath.PowerShell.Tests/Cmdlets/RobotSettingsTests.cs
+++ b/UiPath.PowerShell.Tests/Cmdlets/RobotSettingsTests.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UiPath.PowerShell.Cmdlets;
+using UiPath.PowerShell.Models;
+using UiPath.PowerShell.Tests.Util;
+using UiPath.Web.Client20181.Models;
+
+namespace UiPath.PowerShell.Tests.Cmdlets
+{
+    [TestClass]
+    public class RobotSettingsTests : TestClassBase
+    {
+        [TestMethod]
+        public void RobotSettingsSetThenClear()
+        {
+            using (var runspace = PowershellFactory.CreateAuthenticatedSession(TestContext))
+            {
+                var name = TestRandom.RandomString();
+                var description = TestRandom.RandomString();
+                var machine = TestRandom.RandomString();
+                var username = TestRandom.RandomString();
+                long? robotId = null;
+                License license = null;
+
+                using (var cmdlet = PowershellFactory.CreateCmdlet(runspace))
+                {
+                    cmdlet.AddCommand(UiPathStrings.GetUiPathLicense);
+                    license = Invoke<License>(cmdlet)?.FirstOrDefault();
+
+                    Assert.IsNotNull(license);
+                }
+
+                using (var cmdlet = PowershellFactory.CreateCmdlet(runspace))
+                {
+                    cmdlet.AddCommand(UiPathStrings.AddUiPathRobot)
+                        .AddParameter(UiPathStrings.Name, name)
+                        .AddParameter(UiPathStrings.MachineName, machine)
+                        .AddParameter(UiPathStrings.LicenseKey, license.Code)
+                        .AddParameter(UiPathStrings.Description, description)
+                        .AddParameter(UiPathStrings.Username, username)
+                        .AddParameter(UiPathStrings.Type, RobotDtoType.NonProduction);
+                    var robots = Invoke<Robot>(cmdlet);
+                    
+                    robotId = robots[0].Id;
+                }
+
+                using (var cmdlet = PowershellFactory.CreateCmdlet(runspace))
+                {
+                    cmdlet.AddCommand(UiPathStrings.EditUiPathRobotSettings)
+                        .AddParameter(nameof(EditRobotSettings.Id), robotId)
+                        .AddParameter(nameof(EditRobotSettings.StudioNotifyServer), false)
+                        .AddParameter(nameof(EditRobotSettings.ResolutionHeight), 1920)
+                        .AddParameter(nameof(EditRobotSettings.TracingLevel), "Verbose")
+                        .AddParameter(nameof(EditRobotSettings.LoginToConsole), true);
+                    Invoke<Robot>(cmdlet);
+                }
+
+                using (var cmdlet = PowershellFactory.CreateCmdlet(runspace))
+                {
+                    cmdlet.AddCommand(UiPathStrings.GetUiPathRobotSettings)
+                        .AddParameter(UiPathStrings.Id, robotId);
+                    var robotSettings = Invoke<RobotExecutionSettings>(cmdlet)?.FirstOrDefault();
+
+                    Assert.IsNotNull(robotSettings);
+                    Assert.AreEqual(robotId, robotSettings.Id);
+                    Assert.AreEqual(false, robotSettings.StudioNotifyServer);
+                    Assert.AreEqual(1920, robotSettings.ResolutionHeight);
+                    Assert.AreEqual("Verbose", robotSettings.TracingLevel);
+                    Assert.AreEqual(true, robotSettings.LoginToConsole);
+                    Assert.IsNull(robotSettings.FontSmoothing);
+                    Assert.IsNull(robotSettings.ResolutionWidth);
+                    Assert.IsNull(robotSettings.ResolutionDepth);
+                }
+
+                using (var cmdlet = PowershellFactory.CreateCmdlet(runspace))
+                {
+                    cmdlet.AddCommand(UiPathStrings.ClearUiPathRobotSettings)
+                        .AddParameter(UiPathStrings.Id, robotId)
+                        .AddParameter(nameof(ClearRobotSettings.StudioNotifyServer))
+                        .AddParameter(nameof(ClearRobotSettings.TracingLevel))
+                        .AddParameter(nameof(ClearRobotSettings.ResolutionHeight))
+                        .AddParameter(nameof(ClearRobotSettings.LoginToConsole));
+                    Invoke(cmdlet);
+                }
+
+                using (var cmdlet = PowershellFactory.CreateCmdlet(runspace))
+                {
+                    cmdlet.AddCommand(UiPathStrings.GetUiPathRobotSettings)
+                        .AddParameter(UiPathStrings.Id, robotId);
+                    var robotSettings = Invoke<RobotExecutionSettings>(cmdlet)?.FirstOrDefault();
+
+                    Assert.IsNotNull(robotSettings);
+                    Assert.IsNotNull(robotSettings.Id);
+                    Assert.IsNull(robotSettings.ResolutionHeight);
+                    Assert.IsNull(robotSettings.TracingLevel);
+                    Assert.IsNull(robotSettings.LoginToConsole);
+                    Assert.IsNull(robotSettings.StudioNotifyServer);
+                    Assert.IsNull(robotSettings.FontSmoothing);
+                    Assert.IsNull(robotSettings.ResolutionWidth);
+                    Assert.IsNull(robotSettings.ResolutionDepth);
+                }
+            }
+        }
+    }
+}

--- a/UiPath.PowerShell.Tests/UiPath.PowerShell.Tests.csproj
+++ b/UiPath.PowerShell.Tests/UiPath.PowerShell.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Cmdlets\LibraryTests.cs" />
     <Compile Include="Cmdlets\MergeAddRemoveTests.cs" />
     <Compile Include="Cmdlets\QueueDefinitionsTests.cs" />
+    <Compile Include="Cmdlets\RobotSettingsTests.cs" />
     <Compile Include="Cmdlets\RobotTests.cs" />
     <Compile Include="Cmdlets\RoleTests.cs" />
     <Compile Include="Cmdlets\ScheduleTests.cs" />
@@ -63,6 +64,7 @@
     </Compile>
     <Compile Include="Util\ApiHelper.cs" />
     <Compile Include="Util\PackageSpec.cs" />
+    <Compile Include="Util\TestContextExtensions.cs" />
     <Compile Include="Util\TestFileFixture.cs" />
     <Compile Include="Util\PowershellFactory.cs" />
     <Compile Include="Util\TestClassBase.cs" />

--- a/UiPath.PowerShell.Tests/Util/TestContextExtensions.cs
+++ b/UiPath.PowerShell.Tests/Util/TestContextExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UiPath.PowerShell.Tests.Util
+{
+    internal static class TestContextExtensions
+    {
+        internal static string GetTestParameter(this TestContext testContext, string name)
+        {
+            var propValue = testContext.Properties[name]?.ToString();
+            if (string.IsNullOrWhiteSpace(propValue))
+            {
+                throw new ArgumentException($"Ensure that the \"{name}\" parameter is set in the .runsettings file, and that the .runsettings file has been attached to the test runner.", name);
+            }
+
+            return propValue;
+        }
+    }
+}

--- a/UiPath.PowerShell.Tests/Util/TestSettings.cs
+++ b/UiPath.PowerShell.Tests/Util/TestSettings.cs
@@ -14,19 +14,19 @@ namespace UiPath.PowerShell.Tests.Util
 
         public static TestSettings FromTestContext(TestContext testContext)
         {
-            var url = testContext.Properties["url"];
-            var tenantName = testContext.Properties["tenantName"];
-            var userName = testContext.Properties["userName"];
-            var password = testContext.Properties["password"];
-            var hostPassword = testContext.Properties["hostPassword"];
+            var url = testContext.GetTestParameter("url");
+            var tenantName = testContext.GetTestParameter("tenantName");
+            var userName = testContext.GetTestParameter("userName");
+            var password = testContext.GetTestParameter("password");
+            var hostPassword = testContext.GetTestParameter("hostPassword");
 
             return new TestSettings
             {
-                URL = url?.ToString(),
-                TenantName = tenantName?.ToString(),
-                UserName = userName?.ToString(),
-                Password = password?.ToString(),
-                HostPassword = hostPassword?.ToString()
+                URL = url,
+                TenantName = tenantName,
+                UserName = userName,
+                Password = password,
+                HostPassword = hostPassword
 
             };
         }

--- a/UiPath.PowerShell.Tests/Util/UiPathStrings.cs
+++ b/UiPath.PowerShell.Tests/Util/UiPathStrings.cs
@@ -69,7 +69,10 @@
         public const string EditUiPathRobot = "Edit-UiPathRobot";
         public const string RemoveUiPathRobot = "Remove-UiPathRobot";
 
-
+        public const string GetUiPathRobotSettings = "Get-UiPathRobotSettings";
+        public const string EditUiPathRobotSettings = "Edit-UiPathRobotSettings";
+        public const string ClearUiPathRobotSettings = "Clear-UiPathRobotSettings";
+        
         public const string AddUiPathQueueDefinition = "Add-UiPathQueueDefinition";
         public const string GetUiPathQueueDefinition = "Get-UiPathQueueDefinition";
         public const string EditUiPathQueueDefinition = "Edit-UiPathQueueDefinition";
@@ -101,5 +104,6 @@
         public const string EditUiPathProcessSchedule = "Edit-UiPathProcessSchedule";
         public const string RemoveUiPathProcessSchedule = "Remove-UiPathProcessSchedule";
 
+        public const string GetUiPathLicense = "Get-UiPathLicense";
     }
 }

--- a/UiPath.PowerShell/Cmdlets/ClearAuthToken.cs
+++ b/UiPath.PowerShell/Cmdlets/ClearAuthToken.cs
@@ -7,7 +7,7 @@ namespace UiPath.PowerShell.Cmdlets
     /// <para name="synopsis">Clears the Orchestrator authentication token from the Powershell session.</para>
     /// </summary>
     [Cmdlet(VerbsCommon.Clear, Nouns.AuthToken)]
-    public class ClearAuthToken: UiPathCmdlet
+    public class ClearAuthToken: AuthenticatedCmdlet
     {
         protected override void ProcessRecord()
         {

--- a/UiPath.PowerShell/Cmdlets/ClearRobotSettings.cs
+++ b/UiPath.PowerShell/Cmdlets/ClearRobotSettings.cs
@@ -1,0 +1,72 @@
+﻿using System.Linq;
+using System.Management.Automation;
+using UiPath.PowerShell.Models;
+using UiPath.PowerShell.Util;
+using UiPath.Web.Client20181;
+using UiPath.Web.Client20181.Models;
+
+namespace UiPath.PowerShell.Cmdlets
+{
+    [Cmdlet(VerbsCommon.Clear, Nouns.RobotSettings)]
+    public class ClearRobotSettings: AuthenticatedCmdlet
+    {
+        private const string IdParameterSet = "Id";
+        
+        [ValidateNotNull]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = IdParameterSet)]
+        public long Id { get; set; }
+
+        [SetParameter]
+        [Parameter(Mandatory = false)]
+        public bool TracingLevel { get; set; }
+
+        [SetParameter]
+        [Parameter(Mandatory = false)]
+        public bool LoginToConsole { get; set; }
+
+        [SetParameter]
+        [Parameter(Mandatory = false)]
+        public bool ResolutionWidth { get; set; }
+
+        [SetParameter]
+        [Parameter(Mandatory = false)]
+        public bool ResolutionHeight { get; set; }
+
+        [SetParameter]
+        [Parameter(Mandatory = false)]
+        public bool ResolutionDepth { get; set; }
+
+        [SetParameter]
+        [Parameter(Mandatory = false)]
+        public bool FontSmoothing { get; set; }
+
+        [SetParameter]
+        [Parameter(Mandatory = false)]
+        public bool StudioNotifyServer { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            var robot = HandleHttpOperationException(() => Api.Robots.GetById(Id));
+
+            foreach (var p in this.GetType()
+                .GetProperties()
+                .Where(pi => pi.GetCustomAttributes(true)
+                    .Where(o => o is SetParameterAttribute)
+                    .Any()))
+            {
+                var shouldClear = p.GetValue(this);
+                if (shouldClear != null && (bool)shouldClear && robot.ExecutionSettings.ContainsKey(p.Name))
+                {
+                    robot.ExecutionSettings.Remove(p.Name);
+                }
+            }
+
+            if (!robot.ExecutionSettings.Any())
+            {
+                robot.ExecutionSettings = null;
+            }
+
+            HandleHttpOperationException(() => Api.Robots.PutById(robot.Id.Value, robot));
+        }
+    }
+}

--- a/UiPath.PowerShell/Cmdlets/EditRobotSettings.cs
+++ b/UiPath.PowerShell/Cmdlets/EditRobotSettings.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using UiPath.PowerShell.Models;
+using UiPath.PowerShell.Util;
+using UiPath.Web.Client20181;
+using UiPath.Web.Client20181.Models;
+
+namespace UiPath.PowerShell.Cmdlets
+{
+    [Cmdlet(VerbsData.Edit, Nouns.RobotSettings)]
+    public class EditRobotSettings: EditCmdlet
+    {
+        private const string RobotSettingsParameterSet = "RobotSettings";
+        private const string IdParameterSet = "Id";
+
+        [ValidateNotNull]
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = RobotSettingsParameterSet)]
+        public RobotExecutionSettings RobotSettings { get; set; }
+
+        [ValidateNotNull]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = IdParameterSet)]
+        public long Id { get; set; }
+
+        [SetParameter]
+        [Parameter]
+        public string TracingLevel { get; set; }
+
+        [SetParameter]
+        [Parameter]
+        public bool? LoginToConsole { get; set; }
+
+        [SetParameter]
+        [Parameter]
+        public long? ResolutionWidth { get; set; }
+
+        [SetParameter]
+        [Parameter]
+        public long? ResolutionHeight { get; set; }
+
+        [SetParameter]
+        [Parameter]
+        public long? ResolutionDepth { get; set; }
+
+        [SetParameter]
+        [Parameter]
+        public bool? FontSmoothing { get; set; }
+
+        [SetParameter]
+        [Parameter]
+        public bool? StudioNotifyServer { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            RobotDto robot = null;
+
+            ProcessImpl(() =>
+            {
+                robot = HandleHttpOperationException(() => Api.Robots.GetById(RobotSettings?.Id ?? Id));
+                if (robot.ExecutionSettings == null)
+                {
+                    robot.ExecutionSettings = new Dictionary<string, object>();
+                }
+
+                return RobotExecutionSettings.FromExecutionSettingsDictionary(RobotSettings?.Id ?? Id, robot.ExecutionSettings);
+            }, robotSettings =>
+            {
+                robot.ExecutionSettings = RobotExecutionSettings.ToDictionary(robotSettings);
+                HandleHttpOperationException(() => Api.Robots.PutById(robotSettings.Id, robot));
+            });
+        }
+    }
+}

--- a/UiPath.PowerShell/Cmdlets/GetRobotSettings.cs
+++ b/UiPath.PowerShell/Cmdlets/GetRobotSettings.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using UiPath.PowerShell.Models;
+using UiPath.PowerShell.Util;
+using UiPath.Web.Client20181;
+using UiPath.Web.Client20181.Models;
+using UiPath.Web.Client20183;
+
+namespace UiPath.PowerShell.Cmdlets
+{
+    [Cmdlet(VerbsCommon.Get, Nouns.RobotSettings)]
+    public class GetRobotSettings: FilteredIdCmdlet
+    {
+        [Filter]
+        [Parameter(ParameterSetName = "Filter")]
+        public string Name { get; set; }
+
+        [Filter]
+        [Parameter(ParameterSetName = "Filter")]
+        public string MachineName { get; set; }
+
+        [Filter]
+        [Parameter(ParameterSetName = "Filter")]
+        public string LicenseKey { get; set; }
+
+        [Filter]
+        [Parameter(ParameterSetName = "Filter")]
+        public string Username { get; set; }
+
+        [ValidateEnum(typeof(Web.Client20181.Models.RobotDtoType))]
+        [Filter]
+        [Parameter(ParameterSetName = "Filter")]
+        public string Type { get; private set; }
+
+        [ValidateEnum(typeof(Web.Client20183.Models.RobotDtoHostingType))]
+        [Filter]
+        [Parameter(ParameterSetName = "Filter")]
+        public string HostingType { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            ProcessImpl(
+                filter => Api.Robots.GetRobots(filter: filter).Value.Select(r => RobotExecutionSettings.FromExecutionSettingsDictionary(r.Id.Value, r.ExecutionSettings)).ToList(),
+                id => RobotExecutionSettings.FromExecutionSettingsDictionary(id, Api.Robots.GetById(id)?.ExecutionSettings),
+                dto => dto);
+        }
+    }
+}

--- a/UiPath.PowerShell/Cmdlets/Nouns.cs
+++ b/UiPath.PowerShell/Cmdlets/Nouns.cs
@@ -22,6 +22,7 @@
         internal const string Process = UiPath + "Process";
         internal const string ProcessSchedule = UiPath + "ProcessSchedule";
         internal const string Robot = UiPath + "Robot";
+        internal const string RobotSettings = UiPath + "RobotSettings";
         internal const string Role = UiPath + "Role";
         internal const string RoleUser = UiPath + "RoleUser";
         internal const string RolePermission = UiPath + "RolePermission";
@@ -35,3 +36,4 @@
         internal const string Webhook = UiPath + "Webhook";
     }
 }
+

--- a/UiPath.PowerShell/Models/RobotExecutionSettings.cs
+++ b/UiPath.PowerShell/Models/RobotExecutionSettings.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UiPath.PowerShell.Util;
+
+namespace UiPath.PowerShell.Models
+{
+    [TypeConverter(typeof(UiPathTypeConverter))]
+    public class RobotExecutionSettings
+    {
+        public long Id { get; private set; }
+        public string TracingLevel { get; private set; }
+        public bool? LoginToConsole { get; private set; }
+        public long? ResolutionWidth { get; private set; }
+        public long? ResolutionHeight { get; private set; }
+        public long? ResolutionDepth { get; private set; }
+        public bool? FontSmoothing { get; private set; }
+        public bool? StudioNotifyServer { get; private set; }
+
+        internal static RobotExecutionSettings FromExecutionSettingsDictionary(long id, IDictionary<string, object> executionSettings)
+        {
+            if (executionSettings == null)
+            {
+                return new RobotExecutionSettings();
+            }
+
+            return new RobotExecutionSettings()
+            {
+                Id = id,
+                TracingLevel = TryGetParameterAs<string>(executionSettings, nameof(TracingLevel)),
+                LoginToConsole = TryGetStructParameterAs<bool>(executionSettings, nameof(LoginToConsole)),
+                ResolutionWidth = TryGetStructParameterAs<long>(executionSettings, nameof(ResolutionWidth)),
+                ResolutionHeight = TryGetStructParameterAs<long>(executionSettings, nameof(ResolutionHeight)),
+                ResolutionDepth = TryGetStructParameterAs<long>(executionSettings, nameof(ResolutionDepth)),
+                FontSmoothing = TryGetStructParameterAs<bool>(executionSettings, nameof(FontSmoothing)),
+                StudioNotifyServer = TryGetStructParameterAs<bool>(executionSettings, nameof(StudioNotifyServer))
+            };
+        }
+
+        internal static IDictionary<string, object> ToDictionary(RobotExecutionSettings settings)
+        {
+            var dict = new Dictionary<string, object>();
+            foreach (var p in typeof(RobotExecutionSettings).GetProperties())
+            {
+                if (p.Name == nameof(Id)) continue;
+
+                var value = p.GetValue(settings);
+                if (value != null)
+                {
+                    dict[p.Name] = value;
+                }
+            }
+
+            return dict;
+        }
+
+        private static T TryGetParameterAs<T>(IDictionary<string, object> executionSettings, string name) where T : class
+        {
+            if (!executionSettings.ContainsKey(name))
+            {
+                return null;
+            }
+
+            return executionSettings[name] as T;
+        }
+
+        private static T? TryGetStructParameterAs<T>(IDictionary<string, object> executionSettings, string name) where T : struct
+        {
+            if (!executionSettings.ContainsKey(name))
+            {
+                return null;
+            }
+
+            var p = executionSettings[name];
+            return p as T?;
+        }
+    }
+}

--- a/UiPath.PowerShell/UiPath.PowerShell.csproj
+++ b/UiPath.PowerShell/UiPath.PowerShell.csproj
@@ -51,9 +51,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Cmdlets\ClearRobotSettings.cs" />
+    <Compile Include="Cmdlets\GetRobotSettings.cs" />
+    <Compile Include="Cmdlets\EditRobotSettings.cs" />
     <Compile Include="Cmdlets\GetEnvironmentRobot.cs" />
     <Compile Include="Cmdlets\UnlockUser.cs" />
     <Compile Include="Cmdlets\LockUser.cs" />
+    <Compile Include="Models\RobotExecutionSettings.cs" />
     <Compile Include="Util\UiPathTypeConverter.cs" />
     <Compile Include="Util\UserCmdlet.cs" />
     <Compile Include="Util\BindingResolver.cs" />

--- a/UiPath.PowerShell/Util/AuthenticatedCmdlet.cs
+++ b/UiPath.PowerShell/Util/AuthenticatedCmdlet.cs
@@ -10,6 +10,7 @@ using UiPathWebApi_18_2 = UiPath.Web.Client20182.UiPathWebApi;
 using UiPathWebApi_18_3 = UiPath.Web.Client20183.UiPathWebApi;
 using UiPathWebApi_18_4 = UiPath.Web.Client20184.UiPathWebApi;
 using UiPathWebApi_19_1 = UiPath.Web.Client20191.UiPathWebApi;
+using UiPathWebApi_19_4 = UiPath.Web.Client20194.UiPathWebApi;
 
 namespace UiPath.PowerShell.Util
 {
@@ -29,6 +30,7 @@ namespace UiPath.PowerShell.Util
         private UiPathWebApi_18_3 _api_18_3;
         private UiPathWebApi_18_4 _api_18_4;
         private UiPathWebApi_19_1 _api_19_1;
+        private UiPathWebApi_19_4 _api_19_4;
 
         private TimeSpan Timeout
         {
@@ -136,6 +138,19 @@ namespace UiPath.PowerShell.Util
                     _api_19_1 = MakeApi<UiPathWebApi_19_1>(authToken, (creds, uri) => new UiPathWebApi_19_1(creds) { BaseUri = uri }, Timeout);
                 }
                 return _api_19_1;
+            }
+        }
+
+        protected UiPathWebApi_19_4 Api_19_4
+        {
+            get
+            {
+                if (_api_19_4 == null)
+                {
+                    var authToken = InternalAuthToken;
+                    _api_19_4 = MakeApi<UiPathWebApi_19_4>(authToken, (creds, uri) => new UiPathWebApi_19_4(creds) { BaseUri = uri }, Timeout);
+                }
+                return _api_19_4;
             }
         }
 

--- a/UiPath.Web.Client/Swagger/UiPath2019.4.swagger
+++ b/UiPath.Web.Client/Swagger/UiPath2019.4.swagger
@@ -1,0 +1,19190 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "V2",
+    "title": "UiPath.WebApi"
+  },
+  "host": "platform.uipath.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [],
+  "produces": [],
+  "paths": {
+    "/api/Account/Authenticate": {
+      "post": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Authenticates the user based on user name and password",
+        "description": "Authenticates the user based on user name and password.",
+        "operationId": "Account_Authenticate",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "loginModel",
+            "in": "body",
+            "description": "The login parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LoginModel"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful authentication",
+            "schema": {
+              "$ref": "#/definitions/AjaxResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/Account": {},
+    "/api/logs": {
+      "post": {
+        "tags": [
+          "Logs"
+        ],
+        "summary": "Inserts a log entry with a specified message in JSON format.",
+        "description": "Required permissions: Logs.Create.\r\n\r\nExample of jMessage parameter.\r\n            \r\n     {\r\n         \"message\": \"TTT execution started\",\r\n         \"level\": \"Information\",\r\n         \"timeStamp\": \"2017-01-18T14:46:07.4152893+02:00\",\r\n         \"windowsIdentity\": \"DESKTOP-1L50L0P\\\\WindowsUser\",\r\n         \"agentSessionId\": \"00000000-0000-0000-0000-000000000000\",\r\n         \"processName\": \"TTT\",\r\n         \"fileName\": \"Main\",\r\n         \"jobId\": \"8066c309-cef8-4b47-9163-b273fc14cc43\"\r\n     }",
+        "operationId": "Logs_Post",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "jMessage",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully inserts a log message. Although it's a post, there's no need for an object to be returned"
+          },
+          "400": {
+            "description": "jMessage is null or an Exception is thrown during insert"
+          },
+          "408": {
+            "description": "Too many pending logging requests or timeout"
+          }
+        }
+      }
+    },
+    "/api/Logs/SubmitLogs": {
+      "post": {
+        "tags": [
+          "Logs"
+        ],
+        "summary": "Inserts a collection of log entries, each in a specific JSON format.",
+        "description": "Required permissions: Logs.Create.\r\n\r\nExample of log entry:\r\n     {\r\n         \"message\": \"TTT execution started\",\r\n         \"level\": \"Information\",\r\n         \"timeStamp\": \"2017-01-18T14:46:07.4152893+02:00\",\r\n         \"windowsIdentity\": \"DESKTOP-1L50L0P\\\\WindowsUser\",\r\n         \"agentSessionId\": \"00000000-0000-0000-0000-000000000000\",\r\n         \"processName\": \"TTT\",\r\n         \"fileName\": \"Main\",\r\n         \"jobId\": \"8066c309-cef8-4b47-9163-b273fc14cc43\"\r\n     }",
+        "operationId": "Logs_SubmitLogs",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "logEntries",
+            "in": "body",
+            "description": "Collection of string representations of JSON objects",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully inserts the log entries",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "logs is null or an Exception is thrown during insert"
+          },
+          "408": {
+            "description": "Too many pending logging requests or timeout"
+          }
+        }
+      }
+    },
+    "/api/RobotsService/Heartbeat": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Post to the server a collection of heartbeat messages generated by the Robots from a Machine",
+        "description": "Every 30 seconds the UiPath service running on a Robot Machine posts a collection of heartbeat messages (one for each Robot hosted on the Machine).\r\nThe response is a collection of commands specific to all the Robots defined on that Machine, including the ones that were added in the meanwhile.",
+        "operationId": "RobotsService_Heartbeat",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "payload",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HeartbeatPayload"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/HeartbeatResponse"
+            }
+          },
+          "400": {
+            "description": "hbts is null or empty or an Exception is thrown during insert"
+          }
+        }
+      }
+    },
+    "/api/RobotsService/SubmitJobState": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Post to the server a heartbeat collection with jobs information",
+        "operationId": "RobotsService_SubmitJobState",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "heartbeats",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HeartbeatDto"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job state was updated successfully. No object returned so 200 instead of 201"
+          }
+        }
+      }
+    },
+    "/api/RobotsService/GetProcesses": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Gets from the server all the processes associated with a Robot.",
+        "description": "Gets from the server all the processes associated with a Robot",
+        "operationId": "RobotsService_GetProcesses",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RobotIdentifier"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the processes collection.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PublishedProcess"
+              }
+            }
+          },
+          "400": {
+            "description": "robotKey is null or empty or an Exception is thrown during retrieval"
+          }
+        }
+      }
+    },
+    "/api/RobotsService/StartService": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Gets from the server all the Robots associated with a Machine and having the specified licenseKey.\r\nIf the received payload contains the ServiceUserName, it returns only the Robot with that specific UserName.",
+        "description": "Gets from the server all the Robots associated with a Machine and having the specified licenseKey.",
+        "operationId": "RobotsService_StartService",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "payload",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RobotServicePayload"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/RobotServiceResponse"
+            }
+          },
+          "400": {
+            "description": "No Robots meet the criteria or an Exception is thrown during retrieval"
+          }
+        }
+      }
+    },
+    "/api/RobotsService/StopService": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Called by RobotSvc to disconnect all Robots.",
+        "operationId": "RobotsService_StopService",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "payload",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HeartbeatPayload"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "Exception is thrown"
+          }
+        }
+      }
+    },
+    "/api/RobotsService/BeginSession": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Begins a front-office session.",
+        "operationId": "RobotsService_BeginSession",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RobotIdentifier"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/RobotDetailsDto"
+            }
+          },
+          "400": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          },
+          "409": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/RobotsService/EndSession": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Ends the front-office session.",
+        "operationId": "RobotsService_EndSession",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RobotIdentifier"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": ""
+          },
+          "409": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/RobotsService/GetConnectionData": {
+      "get": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Called by RobotSvc to connect the Robots on the machine it is running on to Orchestrator (under automatic deployment).",
+        "description": "This is the initial handshake between the robot service and Orchestrator, the equivalent of configuring the connection\r\n            info from Robot tray (manual deployment). It is supported only for authorized machines, i.e. the robot machine is part of the\r\n            same AD as Orchestrator. To enforce this, the request must contain the machine identity. The robots must be already provisioned\r\n            in Orchestrator before this step, otherwise RobotSvc will continue to call this method until they are.",
+        "operationId": "RobotsService_GetConnectionData",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "query",
+            "description": "The tenant under which already defined robots are searched for.",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "domainName",
+            "in": "query",
+            "description": "Domain name for the machine where robot is installed. If it's not provided, we'll use the one specified in web.config",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ConnectionData"
+            }
+          },
+          "401": {
+            "description": "Calling machine is not part of the same AD"
+          }
+        }
+      }
+    },
+    "/api/RobotsService/UploadScreenshot": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Uploads a screenshot for the given jobKey and robotKey.",
+        "operationId": "RobotsService_UploadScreenshot",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "required": true,
+            "type": "file"
+          },
+          {
+            "name": "robotKey",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "jobKey",
+            "in": "formData",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/RobotsService/SubmitHeartbeat": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Post to the server a collection of heartbeat messages generated by the Robots from a Machine",
+        "description": "Every 30 seconds the UiPath service running on a Robot Machine posts a collection of heartbeat messages (one for each Robot hosted on the Machine).\r\nThe response is a collection of commands specific to all robots defined on that Machine, including the ones that were added in the meanwhile.\r\nDEPRECATED. Used for Robots with version lower or equal to 18.2",
+        "operationId": "RobotsService_SubmitHeartbeat",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "hbts",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HeartbeatDto"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RobotCommand"
+              }
+            }
+          },
+          "400": {
+            "description": "hbts is null or empty or an Exception is thrown during insert"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/RobotsService/GetAssociatedProcesses": {
+      "get": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Gets from the server all the processes associated with a Robot.",
+        "description": "DEPRECATED. Gets from the server all the processes associated with a Robot",
+        "operationId": "RobotsService_GetAssociatedProcesses",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "robotKey",
+            "in": "query",
+            "description": "The unique key identifying the Robot.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the processes collection.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PublishedProcess"
+              }
+            }
+          },
+          "400": {
+            "description": "robotKey is null or empty or an Exception is thrown during retrieval"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/RobotsService/GetRobotMappings": {
+      "get": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Gets from the server all the Robots associated with a Machine and having the specified licenseKey",
+        "description": "Gets from the server all the Robots associated with a Machine and having the specified licenseKey.\r\nDEPRECATED. Used for Robots with version lower or equal to 18.2",
+        "operationId": "RobotsService_GetRobotMappings",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "licenseKey",
+            "in": "query",
+            "description": "The licenseKey that the returned Robots must have.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "machineName",
+            "in": "query",
+            "description": "The name of the Machine that the returned Robots must be associated with",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RobotDetailsDto"
+              }
+            }
+          },
+          "400": {
+            "description": "No Robots meet the criteria or an Exception is thrown during retrieval"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/RobotsService/AcquireLicense": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Acquire a license.",
+        "operationId": "RobotsService_AcquireLicense",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RobotIdentifier"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "409": {
+            "description": "No available licenses"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/RobotsService/ReleaseLicense": {
+      "post": {
+        "tags": [
+          "RobotsService"
+        ],
+        "summary": "Release active license.",
+        "operationId": "RobotsService_ReleaseLicense",
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/x-www-form-urlencoded"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RobotIdentifier"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/RobotsService": {},
+    "/api/Stats/GetCountStats": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "summary": "Gets the total number of various entities registered in Orchestrator",
+        "description": "Requires authentication.\r\n\r\nReturns the name and the total number of entities registered in Orchestrator for a set of entities.\r\nAll the counted entity types can be seen in the result below.\r\n     [\r\n           {\r\n             \"title\": \"Processes\",\r\n             \"count\": 1\r\n           },\r\n           {\r\n             \"title\": \"Assets\",\r\n             \"count\": 0\r\n           },\r\n           {\r\n             \"title\": \"Queues\",\r\n             \"count\": 0\r\n           },\r\n           {\r\n             \"title\": \"Schedules\",\r\n             \"count\": 0\r\n           }\r\n     ]",
+        "operationId": "Stats_GetCountStats",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CountStats"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Stats/GetSessionsStats": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "summary": "Gets the total number of robots aggregated by Robot State",
+        "description": "Required permissions: Robots.View.\r\n\r\nReturns the total number of Available, Busy, Disconnected and Unresponsive robots respectively.\r\nExample of returned result:\r\n    [\r\n          {\r\n            \"title\": \"Available\",\r\n            \"count\": 1\r\n          },\r\n          {\r\n            \"title\": \"Busy\",\r\n            \"count\": 0\r\n          },\r\n          {\r\n            \"title\": \"Disconnected\",\r\n            \"count\": 1\r\n          },\r\n          {\r\n            \"title\": \"Unresponsive\",\r\n            \"count\": 0\r\n          }\r\n    ]",
+        "operationId": "Stats_GetSessionsStats",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CountStats"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Stats/GetJobsStats": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "summary": "Gets the total number of jobs aggregated by Job State",
+        "description": "Required permissions: Jobs.View.\r\n\r\nReturns the total number of Successful, Faulted and Canceled jobs respectively.\r\nExample of returned result:\r\n    [\r\n          {\r\n            \"title\": \"Successful\",\r\n            \"count\": 0\r\n          },\r\n          {\r\n            \"title\": \"Faulted\",\r\n            \"count\": 0\r\n          },\r\n          {\r\n            \"title\": \"Canceled\",\r\n            \"count\": 0\r\n          }\r\n    ]",
+        "operationId": "Stats_GetJobsStats",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CountStats"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Stats/GetLicenseStats": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "summary": "Gets the licensing usage statistics",
+        "description": "Required permissions: License.View.",
+        "operationId": "Stats_GetLicenseStats",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "query",
+            "description": "The Tenant's Id - can be used when authenticated as Host",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "description": "Number of reported license usage days",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/LicenseStatsModel"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Stats": {},
+    "/api/Status/Get": {
+      "get": {
+        "tags": [
+          "Status"
+        ],
+        "summary": "Returns whether the current endpoint should be serving traffic",
+        "operationId": "Status_Get",
+        "consumes": [],
+        "produces": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/Status/VerifyHostAvailibility": {
+      "get": {
+        "tags": [
+          "Status"
+        ],
+        "description": "Requires authentication.",
+        "operationId": "Status_VerifyHostAvailibility",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/HostAvailabilityDto"
+            }
+          }
+        }
+      }
+    },
+    "/api/Status": {},
+    "/api/Translations/GetTranslations": {
+      "get": {
+        "tags": [
+          "Translations"
+        ],
+        "summary": "Returns a json with translation resources",
+        "operationId": "Translations_GetTranslations",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "lang",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Translations": {},
+    "/odata/Alerts": {
+      "get": {
+        "tags": [
+          "Alerts"
+        ],
+        "summary": "Gets alerts.",
+        "description": "Required permissions: Alerts.View.",
+        "operationId": "Alerts_GetAlerts",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[AlertDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Alerts/UiPath.Server.Configuration.OData.GetUnreadCount()": {
+      "get": {
+        "tags": [
+          "Alerts"
+        ],
+        "summary": "Returns the total number of alerts, per tenant, that haven't been read by the current user.",
+        "description": "Required permissions: Alerts.View.",
+        "operationId": "Alerts_GetUnreadCount",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Alerts/UiPath.Server.Configuration.OData.MarkAsRead": {
+      "post": {
+        "tags": [
+          "Alerts"
+        ],
+        "summary": "Marks alerts as read and returns the remaining number of unread notifications.",
+        "description": "Required permissions: Alerts.View.",
+        "operationId": "Alerts_MarkAsRead",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "markAsReadParameters",
+            "in": "body",
+            "description": "Collection containing the unique identifiers of the notifications that will be marked as read",
+            "required": true,
+            "schema": {
+              "required": [
+                "ids"
+              ],
+              "type": "object",
+              "properties": {
+                "ids": {
+                  "type": "array",
+                  "items": {
+                    "format": "guid",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Alerts/UiPath.Server.Configuration.OData.RaiseProcessAlert": {
+      "post": {
+        "tags": [
+          "Alerts"
+        ],
+        "summary": "Creates a Process Alert",
+        "description": "Required permissions: Alerts.Create.",
+        "operationId": "Alerts_RaiseProcessAlert",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "raiseAlertParameters",
+            "in": "body",
+            "description": "RaiseProcessAlert action parameters",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "processAlert": {
+                  "$ref": "#/definitions/ProcessAlertDto"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Assets": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Get Assets",
+        "description": "Required permissions: Assets.View.",
+        "operationId": "Assets_GetAssets",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[AssetDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Creates an asset",
+        "description": "Required permissions: Assets.Create.",
+        "operationId": "Assets_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "assetDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AssetDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successfully created the asset",
+            "schema": {
+              "$ref": "#/definitions/AssetDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Assets({Id})": {
+      "put": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Edit an asset",
+        "description": "Required permissions: Assets.Edit.",
+        "operationId": "Assets_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "assetDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AssetDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully updated"
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Delete an asset",
+        "description": "Required permissions: Assets.Delete.",
+        "operationId": "Assets_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted the asset"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Assets/UiPath.Server.Configuration.OData.GetRobotAssetByNameForRobotKey": {
+      "post": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Returns the named asset associated to the given robot key.",
+        "description": "Required permissions: Assets.View.",
+        "operationId": "Assets_GetRobotAssetByNameForRobotKey",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "robotAssetParameters",
+            "in": "body",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "robotKey": {
+                  "type": "string"
+                },
+                "assetName": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/RobotAssetDto"
+            }
+          },
+          "400": {
+            "description": "Invalid parameters"
+          },
+          "404": {
+            "description": "Asset or Robot do not exist or the Asset is not available for the specified robot."
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Assets/UiPath.Server.Configuration.OData.GetRobotAssetByRobotId(robotId={robotId},assetName='{assetName}')": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Returns the named asset associated to the given robot Id.",
+        "description": "Required permissions: Assets.View.",
+        "operationId": "Assets_GetRobotAssetByRobotId",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "robotId",
+            "in": "path",
+            "description": "The Id of the robot for which the asset is being fetched.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "assetName",
+            "in": "path",
+            "description": "The name of the asset being fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/RobotAssetDto"
+            }
+          },
+          "400": {
+            "description": "Invalid parameters"
+          },
+          "404": {
+            "description": "Asset or Robot do not exist or the Asset is not available for the specified robot."
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Assets/UiPath.Server.Configuration.OData.GetRobotAsset(robotId='{robotId}',assetName='{assetName}')": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Returns the named asset associated to the given robot key.",
+        "description": "Required permissions: Assets.View.\r\n\r\nDEPRECATED",
+        "operationId": "Assets_GetRobotAssetByRobotidAndAssetname",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "robotId",
+            "in": "path",
+            "description": "The key of the robot for which the asset is being fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "assetName",
+            "in": "path",
+            "description": "The name of the asset being fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/RobotAssetDto"
+            }
+          },
+          "400": {
+            "description": "Invalid parameters"
+          },
+          "404": {
+            "description": "Asset or Robot do not exist or the Asset is not available for the specified robot."
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/odata/AuditLogs": {
+      "get": {
+        "tags": [
+          "AuditLogs"
+        ],
+        "summary": "Gets Audit logs.",
+        "description": "Required permissions: Audit.View.",
+        "operationId": "AuditLogs_GetAuditLogs",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[AuditLogDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/AuditLogs/UiPath.Server.Configuration.OData.GetAuditLogDetails(auditLogId={auditLogId})": {
+      "get": {
+        "tags": [
+          "AuditLogs"
+        ],
+        "summary": "Call operation  GetAuditLogDetails",
+        "description": "Required permissions: Audit.View.",
+        "operationId": "AuditLogs_GetAuditLogDetailsByAuditlogid",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "auditLogId",
+            "in": "path",
+            "description": "parameter: auditLogId",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[AuditLogEntityDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/AuditLogs/UiPath.Server.Configuration.OData.Reports()": {
+      "get": {
+        "tags": [
+          "AuditLogs"
+        ],
+        "summary": "Returns a CSV containing the filtered audit.",
+        "description": "Required permissions: Audit.View.",
+        "operationId": "AuditLogs_Reports",
+        "consumes": [],
+        "produces": [
+          "image/file"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "format": "file",
+              "type": "file"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Environments": {
+      "get": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Gets Environments.",
+        "description": "Required permissions: Environments.View.",
+        "operationId": "Environments_GetEnvironments",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[EnvironmentDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Post new environment",
+        "description": "Required permissions: Environments.Create.",
+        "operationId": "Environments_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "EnvironmentDto",
+            "in": "body",
+            "description": "The entity to post",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EnvironmentDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/EnvironmentDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Environments({Id})": {
+      "get": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Gets a single environment.",
+        "description": "Required permissions: Environments.View.",
+        "operationId": "Environments_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/EnvironmentDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Updates an environment.",
+        "description": "Required permissions: Environments.Edit.",
+        "operationId": "Environments_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "EnvironmentDto",
+            "in": "body",
+            "description": "The entity to put",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EnvironmentDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated"
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Deletes an environment.",
+        "description": "Required permissions: Environments.Delete.",
+        "operationId": "Environments_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Environments/UiPath.Server.Configuration.OData.GetRobotsForEnvironment(key={key})": {
+      "get": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Returns a collection of all robots and, if no other sorting is provided, will place first those belonging to the environment. Allows odata query options.",
+        "description": "Required permissions: Environments.View and Robots.View.",
+        "operationId": "Environments_GetRobotsForEnvironmentByKey",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "The Id of the environment for which the associated robots are placed first.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[RobotDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Environments/UiPath.Server.Configuration.OData.GetRobotIdsForEnvironment(key={key})": {
+      "get": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Returns a collection of all the ids of the robots associated to an environment based on environment Id.",
+        "description": "Required permissions: Environments.View and Robots.View.",
+        "operationId": "Environments_GetRobotIdsForEnvironmentByKey",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "The Id of the environment for which the robot ids are fetched.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[Int64]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Environments({Id})/UiPath.Server.Configuration.OData.AddRobot": {
+      "post": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Associates a robot with the given environment.",
+        "description": "Required permissions: Environments.Edit.",
+        "operationId": "Environments_AddRobotById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "addRobotParameters",
+            "in": "body",
+            "description": "RobotId - The associated robot Id.",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "robotId": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Nothing returned"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Environments({Id})/UiPath.Server.Configuration.OData.RemoveRobot": {
+      "post": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Dissociates a robot from the given environment.",
+        "description": "Required permissions: Environments.Edit.",
+        "operationId": "Environments_RemoveRobotById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "removeRobotParameters",
+            "in": "body",
+            "description": "RobotId - The dissociated robot Id.",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "robotId": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Environments({Id})/UiPath.Server.Configuration.OData.SetRobots": {
+      "post": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Associates a group of robots with and dissociates another group of robots from the given environment.",
+        "description": "Required permissions: Environments.Edit.",
+        "operationId": "Environments_SetRobotsById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "setRobotsParameters",
+            "in": "body",
+            "description": "<para />addedRobotIds - The id of the robots to be associated with the environment.\r\n            <para />removedRobotIds - The id of the robots to be dissociated from the environment.",
+            "required": true,
+            "schema": {
+              "required": [
+                "addedRobotIds",
+                "removedRobotIds"
+              ],
+              "type": "object",
+              "properties": {
+                "addedRobotIds": {
+                  "type": "array",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "removedRobotIds": {
+                  "type": "array",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Nothing returned"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/ExecutionMedia": {
+      "get": {
+        "tags": [
+          "ExecutionMedia"
+        ],
+        "summary": "Returns the EntitySet ExecutionMedia",
+        "description": "Required permissions: ExecutionMedia.View.",
+        "operationId": "ExecutionMedia_GetExecutionMedia",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[ExecutionMediaDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/ExecutionMedia({Id})": {
+      "get": {
+        "tags": [
+          "ExecutionMedia"
+        ],
+        "summary": "Returns the entity with the key from ExecutionMedia",
+        "description": "Required permissions: ExecutionMedia.View.",
+        "operationId": "ExecutionMedia_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ExecutionMediaDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/ExecutionMedia/UiPath.Server.Configuration.OData.DownloadMediaByJobId(jobId={jobId})": {
+      "get": {
+        "tags": [
+          "ExecutionMedia"
+        ],
+        "summary": "Call operation  DownloadMediaByJobId",
+        "description": "Required permissions: ExecutionMedia.View.",
+        "operationId": "ExecutionMedia_DownloadMediaByJobId",
+        "consumes": [],
+        "produces": [
+          "image/file"
+        ],
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "description": "parameter: jobId",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "200": {
+            "description": "OK",
+            "schema": {
+              "format": "file",
+              "type": "file"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/ExecutionMedia/UiPath.Server.Configuration.OData.DeleteMediaByJobId": {
+      "post": {
+        "tags": [
+          "ExecutionMedia"
+        ],
+        "summary": "Deletes the execution media for the given job key.",
+        "description": "Required permissions: ExecutionMedia.View.",
+        "operationId": "ExecutionMedia_DeleteMediaByJobId",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "deleteMediaByJobParameters",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "required": [
+                "jobId"
+              ],
+              "type": "object",
+              "properties": {
+                "jobId": {
+                  "format": "int64",
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/HostLicenses": {
+      "get": {
+        "tags": [
+          "HostLicenses"
+        ],
+        "summary": "Gets host licenses.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "HostLicenses_GetHostLicenses",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[HostLicenseDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/HostLicenses({Id})": {
+      "get": {
+        "tags": [
+          "HostLicenses"
+        ],
+        "summary": "Gets a single host license based on its key.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "HostLicenses_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/HostLicenseDto"
+            }
+          },
+          "404": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "HostLicenses"
+        ],
+        "summary": "Deletes a host license based on its key.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "HostLicenses_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "404": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/HostLicenses/UiPath.Server.Configuration.OData.UploadLicense": {
+      "post": {
+        "tags": [
+          "HostLicenses"
+        ],
+        "summary": "Uploads a new host license file that was previously generated with Regutil.\r\nThe content of the license is sent as a file embedded in the HTTP request.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "HostLicenses_UploadLicense",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/HostLicenseDto"
+            }
+          },
+          "400": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/HostLicenses/UiPath.Server.Configuration.OData.GetTenantLicense(tenantId={tenantId})": {
+      "get": {
+        "tags": [
+          "HostLicenses"
+        ],
+        "summary": "Gets a single tenant license based on its id.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "HostLicenses_GetTenantLicenseByTenantid",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/LicenseDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/HostLicenses/UiPath.Server.Configuration.OData.DeleteTenantLicense": {
+      "post": {
+        "tags": [
+          "HostLicenses"
+        ],
+        "summary": "Deletes a tenant license based on its key.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "HostLicenses_DeleteTenantLicense",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "deleteTenantLicenseParameters",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "required": [
+                "tenantId"
+              ],
+              "type": "object",
+              "properties": {
+                "tenantId": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "400": {
+            "description": "Invalid parameters"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/HostLicenses/UiPath.Server.Configuration.OData.SetTenantLicense": {
+      "post": {
+        "tags": [
+          "HostLicenses"
+        ],
+        "summary": "Sets the license for a specific tenant",
+        "description": "Host only. Requires authentication.",
+        "operationId": "HostLicenses_SetTenantLicense",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "setTenantLicenseParameters",
+            "in": "body",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "license": {
+                  "$ref": "#/definitions/HostLicensePerTenantDto"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "400": {
+            "description": "Invalid parameters"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Jobs": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Gets Jobs.",
+        "description": "Required permissions: Jobs.View.",
+        "operationId": "Jobs_GetJobs",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[JobDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Jobs({Id})": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Gets a single job.",
+        "description": "Required permissions: Jobs.View.",
+        "operationId": "Jobs_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/JobDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Jobs/UiPath.Server.Configuration.OData.StartJobs": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Adds a new job and sets it in Pending state for each robot based on the input parameters and notifies the respective robots about the pending job.",
+        "description": "Required permissions: Jobs.Create.",
+        "operationId": "Jobs_StartJobs",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "startJobParameters",
+            "in": "body",
+            "description": "StartInfo - The information required to register the new jobs.",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "startInfo": {
+                  "$ref": "#/definitions/StartProcessDto"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[JobDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Jobs({Id})/UiPath.Server.Configuration.OData.StopJob": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Cancels or terminates the specified job.",
+        "description": "Required permissions: Jobs.Edit.",
+        "operationId": "Jobs_StopJobById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "stopJobParameters",
+            "in": "body",
+            "description": "Strategy - States whether a job should be soft stopped or killed immediately.",
+            "required": true,
+            "schema": {
+              "required": [
+                "strategy"
+              ],
+              "type": "object",
+              "properties": {
+                "strategy": {
+                  "enum": [
+                    "SoftStop",
+                    "Kill"
+                  ],
+                  "type": "string",
+                  "x-ms-enum": {
+                    "name": "StopJobParametersEnum",
+                    "modelAsString": false
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Jobs/UiPath.Server.Configuration.OData.StopJobs": {
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Cancels or terminates the specified jobs.",
+        "description": "Required permissions: Jobs.Edit.",
+        "operationId": "Jobs_StopJobs",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "stopJobsParameters",
+            "in": "body",
+            "description": "JobIds - The ids for the jobs to be canceled or terminated;\r\n            Strategy - States whether a job should be soft stopped or killed immediately.",
+            "required": true,
+            "schema": {
+              "required": [
+                "jobIds",
+                "strategy"
+              ],
+              "type": "object",
+              "properties": {
+                "jobIds": {
+                  "type": "array",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "strategy": {
+                  "enum": [
+                    "SoftStop",
+                    "Kill"
+                  ],
+                  "type": "string",
+                  "x-ms-enum": {
+                    "name": "StopJobsParametersEnum",
+                    "modelAsString": false
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Libraries": {
+      "get": {
+        "tags": [
+          "Libraries"
+        ],
+        "summary": "Gets the library packages.",
+        "description": "Required permissions: Libraries.View.",
+        "operationId": "Libraries_GetLibraries",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[LibraryDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Libraries('{Id}')": {
+      "delete": {
+        "tags": [
+          "Libraries"
+        ],
+        "summary": "Deletes a package.",
+        "description": "Required permissions: Libraries.Delete.",
+        "operationId": "Libraries_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "200": {
+            "description": "Package deleted"
+          },
+          "400": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Libraries/UiPath.Server.Configuration.OData.GetVersions(packageId='{packageId}')": {
+      "get": {
+        "tags": [
+          "Libraries"
+        ],
+        "summary": "Returns a collection of all available versions of a given package. Allows odata query options.",
+        "description": "Required permissions: Libraries.View.",
+        "operationId": "Libraries_GetVersionsByPackageid",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "packageId",
+            "in": "path",
+            "description": "The Id of the package for which the versions are fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[LibraryDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Libraries/UiPath.Server.Configuration.OData.DownloadPackage(key='{key}')": {
+      "get": {
+        "tags": [
+          "Libraries"
+        ],
+        "summary": "Downloads the .nupkg file of a Package.",
+        "description": "Required permissions: Libraries.View.",
+        "operationId": "Libraries_DownloadPackageByKey",
+        "consumes": [],
+        "produces": [
+          "image/file"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "format": "file",
+              "type": "file"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Libraries/UiPath.Server.Configuration.OData.UploadPackage": {
+      "post": {
+        "tags": [
+          "Libraries"
+        ],
+        "summary": "Uploads a new package or a new version of an existing package. The content of the package is sent as a .nupkg file embedded in the HTTP request.",
+        "description": "Required permissions: Libraries.Create.",
+        "operationId": "Libraries_UploadPackage",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/LicensesNamedUser/UiPath.Server.Configuration.OData.GetLicensesNamedUser(robotType='{robotType}')": {
+      "get": {
+        "tags": [
+          "LicensesNamedUser"
+        ],
+        "summary": "Gets named-user licenses.",
+        "description": "Required permissions: License.View.",
+        "operationId": "LicensesNamedUser_GetLicensesNamedUserByRobottype",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "robotType",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "NonProduction",
+              "Attended",
+              "Unattended",
+              "Development"
+            ]
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[LicenseNamedUserDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/LicensesRuntime/UiPath.Server.Configuration.OData.GetLicensesRuntime(robotType='{robotType}')": {
+      "get": {
+        "tags": [
+          "LicensesRuntime"
+        ],
+        "summary": "Gets runtime licenses.",
+        "description": "Required permissions: License.View.",
+        "operationId": "LicensesRuntime_GetLicensesRuntimeByRobottype",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "robotType",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "NonProduction",
+              "Attended",
+              "Unattended",
+              "Development"
+            ]
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[LicenseRuntimeDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/LicensesRuntime('{Key}')/UiPath.Server.Configuration.OData.ToggleEnabled": {
+      "post": {
+        "tags": [
+          "LicensesRuntime"
+        ],
+        "summary": "Toggles machine licensing on/off.",
+        "description": "Required permissions: Machines.Edit.",
+        "operationId": "LicensesRuntime_ToggleEnabledByKey",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Key",
+            "in": "path",
+            "description": "key: Key",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "toggleMachineLicenseParameters",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "required": [
+                "robotType",
+                "enabled"
+              ],
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "robotType": {
+                  "enum": [
+                    "NonProduction",
+                    "Attended",
+                    "Unattended",
+                    "Development"
+                  ],
+                  "type": "string",
+                  "x-ms-enum": {
+                    "name": "ToggleMachineLicenseParametersEnum",
+                    "modelAsString": false
+                  }
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "409": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Machines": {
+      "get": {
+        "tags": [
+          "Machines"
+        ],
+        "summary": "Gets machines.",
+        "description": "Required permissions: Machines.View.",
+        "operationId": "Machines_GetMachines",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[MachineDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Machines"
+        ],
+        "summary": "Creates a new machine.",
+        "description": "Required permissions: Machines.Create.",
+        "operationId": "Machines_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "machineDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MachineDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/MachineDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Machines({Id})": {
+      "get": {
+        "tags": [
+          "Machines"
+        ],
+        "summary": "Gets a single machine based on its key.",
+        "description": "Required permissions: Machines.View.",
+        "operationId": "Machines_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/MachineDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "Machines"
+        ],
+        "summary": "Edits a machine based on its key.",
+        "description": "Required permissions: Machines.Edit.",
+        "operationId": "Machines_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "machineDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MachineDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/MachineDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Machines"
+        ],
+        "summary": "Deletes a machine based on its key.",
+        "description": "Required permissions: Machines.Delete.",
+        "operationId": "Machines_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      },
+      "patch": {
+        "tags": [
+          "Machines"
+        ],
+        "summary": "Partially updates a machine.",
+        "description": "Required permissions: Machines.Edit.",
+        "operationId": "Machines_PatchById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "machineDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MachineDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Machines/UiPath.Server.Configuration.OData.DeleteBulk": {
+      "post": {
+        "tags": [
+          "Machines"
+        ],
+        "summary": "Deletes multiple machines based on their keys.",
+        "description": "Required permissions: Machines.Delete.",
+        "operationId": "Machines_DeleteBulk",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "machinesDeleteBulk",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "required": [
+                "machineIds"
+              ],
+              "type": "object",
+              "properties": {
+                "machineIds": {
+                  "type": "array",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "Empty machineIds collection in payload"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/MessageTemplates": {
+      "get": {
+        "tags": [
+          "MessageTemplates"
+        ],
+        "summary": "Gets the message templates.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "MessageTemplates_GetMessageTemplates",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[MessageTemplateDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/MessageTemplates('{Id}')": {
+      "put": {
+        "tags": [
+          "MessageTemplates"
+        ],
+        "summary": "Edits a message template.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "MessageTemplates_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "MessageTemplateDto",
+            "in": "body",
+            "description": "The entity to put",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MessageTemplateDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/MessageTemplateDto"
+            }
+          },
+          "400": {
+            "description": "No message template was found with the given name."
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Permissions": {
+      "get": {
+        "tags": [
+          "Permissions"
+        ],
+        "summary": "Gets permissions.",
+        "operationId": "Permissions_GetPermissions",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[PermissionDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Processes": {
+      "get": {
+        "tags": [
+          "Processes"
+        ],
+        "summary": "Gets the processes.",
+        "description": "Required permissions: Packages.View.",
+        "operationId": "Processes_GetProcesses",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[ProcessDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Processes('{Id}')": {
+      "delete": {
+        "tags": [
+          "Processes"
+        ],
+        "summary": "Deletes a package.",
+        "description": "Required permissions: Packages.Delete.",
+        "operationId": "Processes_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "200": {
+            "description": "Package deleted"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Processes/UiPath.Server.Configuration.OData.GetProcessVersions(processId='{processId}')": {
+      "get": {
+        "tags": [
+          "Processes"
+        ],
+        "summary": "Returns a collection of all available versions of a given process. Allows odata query options.",
+        "description": "Required permissions: Packages.View.",
+        "operationId": "Processes_GetProcessVersionsByProcessid",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "processId",
+            "in": "path",
+            "description": "The Id of the process for which the versions are fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[ProcessDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Processes/UiPath.Server.Configuration.OData.DownloadPackage(key='{key}')": {
+      "get": {
+        "tags": [
+          "Processes"
+        ],
+        "summary": "Downloads the .nupkg file of a Package.",
+        "description": "Required permissions: Packages.View.",
+        "operationId": "Processes_DownloadPackageByKey",
+        "consumes": [],
+        "produces": [
+          "image/file"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "format": "file",
+              "type": "file"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage": {
+      "post": {
+        "tags": [
+          "Processes"
+        ],
+        "summary": "Uploads a new package or a new version of an existing package. The content of the package is sent as a .nupkg file embedded in the HTTP request.",
+        "description": "Required permissions: Packages.Create.",
+        "operationId": "Processes_UploadPackage",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Processes/UiPath.Server.Configuration.OData.GetArguments(key='{key}')": {
+      "get": {
+        "tags": [
+          "Processes"
+        ],
+        "summary": "Get process parameters",
+        "description": "Required permissions: Packages.View.",
+        "operationId": "Processes_GetArgumentsByKey",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ArgumentMetadata"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Processes/UiPath.Server.Configuration.OData.SetArguments": {
+      "post": {
+        "tags": [
+          "Processes"
+        ],
+        "summary": "Saves process arguments",
+        "description": "Required permissions: Packages.Edit.",
+        "operationId": "Processes_SetArguments",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "setArgumentsParameters",
+            "in": "body",
+            "description": "SetArguments action parameters",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "arguments": {
+                  "$ref": "#/definitions/ArgumentMetadata"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/ProcessSchedules": {
+      "get": {
+        "tags": [
+          "ProcessSchedules"
+        ],
+        "summary": "Gets the process schedules.",
+        "description": "Required permissions: Schedules.View.",
+        "operationId": "ProcessSchedules_GetProcessSchedules",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[ProcessScheduleDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "ProcessSchedules"
+        ],
+        "summary": "Creates a new process schedule.",
+        "description": "Required permissions: Schedules.Create.",
+        "operationId": "ProcessSchedules_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "ProcessScheduleDto",
+            "in": "body",
+            "description": "The entity to post",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProcessScheduleDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ProcessScheduleDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/ProcessSchedules({Id})": {
+      "get": {
+        "tags": [
+          "ProcessSchedules"
+        ],
+        "summary": "Gets a single process schedule based on its key.",
+        "description": "Required permissions: Schedules.View.",
+        "operationId": "ProcessSchedules_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ProcessScheduleDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "ProcessSchedules"
+        ],
+        "summary": "Edits a process schedule.",
+        "description": "Required permissions: Schedules.Edit.",
+        "operationId": "ProcessSchedules_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "ProcessScheduleDto",
+            "in": "body",
+            "description": "The entity to put",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProcessScheduleDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ProcessScheduleDto"
+            }
+          },
+          "204": {
+            "description": "Successful put",
+            "schema": {
+              "$ref": "#/definitions/ProcessScheduleDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "ProcessSchedules"
+        ],
+        "summary": "Deletes a process schedule.",
+        "description": "Required permissions: Schedules.Delete.",
+        "operationId": "ProcessSchedules_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/ProcessSchedules/UiPath.Server.Configuration.OData.SetEnabled": {
+      "post": {
+        "tags": [
+          "ProcessSchedules"
+        ],
+        "summary": "Enables/disables a group of schedules.",
+        "description": "Required permissions: Schedules.Edit.",
+        "operationId": "ProcessSchedules_SetEnabled",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "setEnabledParameters",
+            "in": "body",
+            "description": "<para />Enabled - If true the schedules will be enabled, if false the schedules will be disabled.\r\n            <para />ScheduleIds - The collection of ids of the affected schedules.",
+            "required": true,
+            "schema": {
+              "required": [
+                "scheduleIds",
+                "enabled"
+              ],
+              "type": "object",
+              "properties": {
+                "scheduleIds": {
+                  "type": "array",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[Boolean]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/ProcessSchedules/UiPath.Server.Configuration.OData.GetRobotIdsForSchedule(key={key})": {
+      "get": {
+        "tags": [
+          "ProcessSchedules"
+        ],
+        "summary": "Returns a collection of all the ids of the robots associated to an schedule based on schedule Id.",
+        "description": "Required permissions: Schedules.View.",
+        "operationId": "ProcessSchedules_GetRobotIdsForScheduleByKey",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "The Id of the schedule for which the robot ids are fetched.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[Int64]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueDefinitions": {
+      "get": {
+        "tags": [
+          "QueueDefinitions"
+        ],
+        "summary": "Gets the list of queue definitions.",
+        "description": "Required permissions: Queues.View.",
+        "operationId": "QueueDefinitions_GetQueueDefinitions",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[QueueDefinitionDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "QueueDefinitions"
+        ],
+        "summary": "Creates a new queue.",
+        "description": "Required permissions: Queues.Create.",
+        "operationId": "QueueDefinitions_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "QueueDefinitionDto",
+            "in": "body",
+            "description": "The entity to post",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueueDefinitionDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/QueueDefinitionDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueDefinitions({Id})": {
+      "get": {
+        "tags": [
+          "QueueDefinitions"
+        ],
+        "summary": "Gets a single queue definition based on its Id.",
+        "description": "Required permissions: Queues.View.",
+        "operationId": "QueueDefinitions_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/QueueDefinitionDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "QueueDefinitions"
+        ],
+        "summary": "Edits a queue.",
+        "description": "Required permissions: Queues.Edit.",
+        "operationId": "QueueDefinitions_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "queueDefinitionDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueueDefinitionDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/QueueDefinitionDto"
+            }
+          },
+          "409": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "QueueDefinitions"
+        ],
+        "summary": "Deletes a queue based on its key.",
+        "description": "Required permissions: Queues.Delete.",
+        "operationId": "QueueDefinitions_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueDefinitions({Id})/UiPathODataSvc.Reports()": {
+      "get": {
+        "tags": [
+          "QueueDefinitions"
+        ],
+        "summary": "Returns an Excel file containing all the items in the given queue.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueDefinitions_ReportsById",
+        "consumes": [],
+        "produces": [
+          "image/file"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "format": "file",
+              "type": "file"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItemComments": {
+      "get": {
+        "tags": [
+          "QueueItemComments"
+        ],
+        "summary": "Gets the QueueItemComments.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueItemComments_GetQueueItemComments",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[QueueItemCommentDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "QueueItemComments"
+        ],
+        "summary": "Creates a QueueItemComment.",
+        "description": "Required permissions: Queues.View and Transactions.Edit.",
+        "operationId": "QueueItemComments_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "queueItemCommentDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueueItemCommentDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/QueueItemCommentDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItemComments({Id})": {
+      "get": {
+        "tags": [
+          "QueueItemComments"
+        ],
+        "summary": "Gets a QueueItemComment by Id.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueItemComments_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/QueueItemCommentDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "QueueItemComments"
+        ],
+        "summary": "Replace entity in EntitySet QueueItemComments",
+        "description": "Required permissions: Queues.View and Transactions.Edit.",
+        "operationId": "QueueItemComments_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "queueItemCommentDto",
+            "in": "body",
+            "description": "The entity to put",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueueItemCommentDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "QueueItemComments"
+        ],
+        "summary": "Deletes a QueueItemComment.",
+        "description": "Required permissions: Queues.View and Transactions.Edit.",
+        "operationId": "QueueItemComments_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItemComments/UiPath.Server.Configuration.OData.GetQueueItemCommentsHistory(queueItemId={queueItemId})": {
+      "get": {
+        "tags": [
+          "QueueItemComments"
+        ],
+        "summary": "Returns a collection of Queue Item Comments associated to a Queue Item and all its related Queue Items.\r\nA Queue Item is related to another if it was created as a retry of a failed Queue Item. They also share the same Key.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueItemComments_GetQueueItemCommentsHistoryByQueueitemid",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "queueItemId",
+            "in": "path",
+            "description": "The Id of the Queue Item for which the comment history is requested.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[QueueItemCommentDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItemEvents": {
+      "get": {
+        "tags": [
+          "QueueItemEvents"
+        ],
+        "summary": "Gets the QueueItemEvents.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueItemEvents_GetQueueItemEvents",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[QueueItemEventDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItemEvents({Id})": {
+      "get": {
+        "tags": [
+          "QueueItemEvents"
+        ],
+        "summary": "Gets a QueueItemEvent by Id.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueItemEvents_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/QueueItemEventDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItemEvents/UiPath.Server.Configuration.OData.GetQueueItemEventsHistory(queueItemId={queueItemId})": {
+      "get": {
+        "tags": [
+          "QueueItemEvents"
+        ],
+        "summary": "Returns a collection of Queue Item Events associated to a Queue Item and all its related Queue Items.\r\nA Queue Item is related to another if it was created as a retry of a failed Queue Item. They also share the same Key.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueItemEvents_GetQueueItemEventsHistoryByQueueitemid",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "queueItemId",
+            "in": "path",
+            "description": "The Id of the Queue Item for which the event history is requested.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[QueueItemEventDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItems": {
+      "get": {
+        "tags": [
+          "QueueItems"
+        ],
+        "summary": "Gets a collection of queue items.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueItems_GetQueueItems",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[QueueItemDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItems({Id})": {
+      "get": {
+        "tags": [
+          "QueueItems"
+        ],
+        "summary": "Gets a queue item by Id.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueItems_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/QueueItemDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "QueueItems"
+        ],
+        "summary": "Deletes a queue item by Id.",
+        "description": "Required permissions: Queues.View and Transactions.Delete.",
+        "operationId": "QueueItems_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItems({Id})/UiPathODataSvc.GetItemProcessingHistory()": {
+      "get": {
+        "tags": [
+          "QueueItems"
+        ],
+        "summary": "Returns data about the processing history of the given queue item. Allows odata query options.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueItems_GetItemProcessingHistoryById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[QueueItemDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItems/UiPathODataSvc.SetItemReviewStatus": {
+      "post": {
+        "tags": [
+          "QueueItems"
+        ],
+        "summary": "Updates the review status of the specified queue items to an indicated state.",
+        "description": "Required permissions: Queues.View and Transactions.Edit.",
+        "operationId": "QueueItems_SetItemReviewStatus",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "itemReviewStatusParameters",
+            "in": "body",
+            "description": "<para />QueueItems - The collection of ids of queue items for which the state is set.\r\n            <para />Status - The new value for the review status.",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string"
+                },
+                "queueItems": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/LongVersionedEntity"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/BulkOperationResponseDto[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItems/UiPathODataSvc.DeleteBulk": {
+      "post": {
+        "tags": [
+          "QueueItems"
+        ],
+        "summary": "Sets the given queue items' status to Deleted.",
+        "description": "Required permissions: Queues.View and Transactions.Delete.",
+        "operationId": "QueueItems_DeleteBulk",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "deleteBulkParameters",
+            "in": "body",
+            "description": "QueueItems - The collection of ids of queue items to delete.",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "queueItems": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/LongVersionedEntity"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/BulkOperationResponseDto[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItems({Id})/UiPathODataSvc.SetTransactionProgress": {
+      "post": {
+        "tags": [
+          "QueueItems"
+        ],
+        "summary": "Updates the progress field of a queue item with the status 'In Progress'.",
+        "description": "Required permissions: Queues.View and Transactions.Edit.",
+        "operationId": "QueueItems_SetTransactionProgressById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "transactionProgressParameters",
+            "in": "body",
+            "description": "<para />QueueItemId - The item's id.\r\n            <para />Progress - The value for the Progress field.",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "progress": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItems/UiPathODataSvc.SetItemReviewer": {
+      "post": {
+        "tags": [
+          "QueueItems"
+        ],
+        "summary": "Sets the reviewer for multiple queue items",
+        "description": "Required permissions: Queues.View and Transactions.Edit.",
+        "operationId": "QueueItems_SetItemReviewer",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "setReviewerBulkParameters",
+            "in": "body",
+            "description": "<para />UserId - The ID of the user to be set as the reviewer. If not set, the reviewer is cleared.\r\n            <para />QueueItems - The collection of ids of queue items for which the reviewer is set.",
+            "required": true,
+            "schema": {
+              "required": [
+                "userId"
+              ],
+              "type": "object",
+              "properties": {
+                "userId": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "queueItems": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/LongVersionedEntity"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/BulkOperationResponseDto[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItems/UiPathODataSvc.UnsetItemReviewer": {
+      "post": {
+        "tags": [
+          "QueueItems"
+        ],
+        "summary": "Unsets the reviewer for multiple queue items",
+        "description": "Required permissions: Queues.View and Transactions.Edit.",
+        "operationId": "QueueItems_UnsetItemReviewer",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "unsetReviewerBulkParameters",
+            "in": "body",
+            "description": "<para />QueueItems - The collection of ids of queue items for which the reviewer is unset.",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "queueItems": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/LongVersionedEntity"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/BulkOperationResponseDto[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueItems/UiPath.Server.Configuration.OData.GetReviewers()": {
+      "get": {
+        "tags": [
+          "QueueItems"
+        ],
+        "summary": "Returns a collection of users having the permission for Queue Items review. Allows odata query options.",
+        "description": "Required permissions: Queues.View and Transactions.Edit.",
+        "operationId": "QueueItems_GetReviewers",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[UserDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueProcessingRecords/UiPathODataSvc.RetrieveLastDaysProcessingRecords(daysNo={daysNo},queueDefinitionId={queueDefinitionId})": {
+      "get": {
+        "tags": [
+          "QueueProcessingRecords"
+        ],
+        "summary": "Returns the computed processing status for a given queue in the last specified days.",
+        "description": "Required permissions: Queues.View and Transactions.View.",
+        "operationId": "QueueProcessingRecords_RetrieveLastDaysProcessingRecordsByDaysnoAndQueuedefinitionid",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "daysNo",
+            "in": "path",
+            "description": "The number of days to go back from the present moment when calculating the report. If it is 0 the report will be computed for the last hour.",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "queueDefinitionId",
+            "in": "path",
+            "description": "The Id of the queue for which the report is computed.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[QueueProcessingRecordDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/QueueProcessingRecords/UiPathODataSvc.RetrieveQueuesProcessingStatus()": {
+      "get": {
+        "tags": [
+          "QueueProcessingRecords"
+        ],
+        "summary": "Returns the processing status for all queues. Allows odata query options.",
+        "description": "Required permissions: Queues.View.",
+        "operationId": "QueueProcessingRecords_RetrieveQueuesProcessingStatus",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[QueueProcessingStatusDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Queues/UiPathODataSvc.StartTransaction": {
+      "post": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Starts a transaction.",
+        "description": "Required permissions: Queues.View and Transactions.View and Transactions.Create and Transactions.Edit.",
+        "operationId": "Queues_StartTransaction",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "startTransactionParameters",
+            "in": "body",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "transactionData": {
+                  "$ref": "#/definitions/TransactionDataDto"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "schema": {
+              "$ref": "#/definitions/QueueItemDto"
+            }
+          },
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/QueueItemDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Queues/UiPathODataSvc.AddQueueItem": {
+      "post": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Adds a new queue item.",
+        "description": "Required permissions: Queues.View and Transactions.Create.",
+        "operationId": "Queues_AddQueueItem",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "queueItemParameters",
+            "in": "body",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "itemData": {
+                  "$ref": "#/definitions/QueueItemDataDto"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/QueueItemDto"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/QueueItemDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Queues/UiPathODataSvc.BulkAddQueueItems": {
+      "post": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Call operation  BulkAddQueueItems",
+        "description": "Required permissions: Queues.View and Transactions.Create.",
+        "operationId": "Queues_BulkAddQueueItems",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "bulkAddQueueItemsParameters",
+            "in": "body",
+            "description": "BulkAddQueueItems action parameters",
+            "required": true,
+            "schema": {
+              "required": [
+                "commitType"
+              ],
+              "type": "object",
+              "properties": {
+                "queueName": {
+                  "type": "string"
+                },
+                "commitType": {
+                  "enum": [
+                    "AllOrNothing",
+                    "StopOnFirstFailure",
+                    "ProcessAllIndependently"
+                  ],
+                  "type": "string",
+                  "x-ms-enum": {
+                    "name": "BulkAddQueueItemsParametersEnum",
+                    "modelAsString": false
+                  }
+                },
+                "queueItems": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/QueueItemDataDto"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BulkOperationResponseDto[FailedQueueItemDto]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Queues({Id})/UiPathODataSvc.SetTransactionResult": {
+      "post": {
+        "tags": [
+          "Queues"
+        ],
+        "summary": "Sets the result of a transaction.",
+        "description": "Required permissions: Queues.View and Transactions.Edit.",
+        "operationId": "Queues_SetTransactionResultById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "setTransactionParameters",
+            "in": "body",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "transactionResult": {
+                  "$ref": "#/definitions/TransactionResultDto"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Releases": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "summary": "Gets multiple releases.",
+        "description": "Required permissions: Processes.View.",
+        "operationId": "Releases_GetReleases",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[ReleaseDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Releases"
+        ],
+        "summary": "Creates a new release.",
+        "description": "Required permissions: Processes.Create.",
+        "operationId": "Releases_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "ReleaseDto",
+            "in": "body",
+            "description": "The entity to post",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReleaseDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/ReleaseDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Releases({Id})": {
+      "get": {
+        "tags": [
+          "Releases"
+        ],
+        "summary": "Gets a release.",
+        "description": "Required permissions: Processes.View.",
+        "operationId": "Releases_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ReleaseDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "Releases"
+        ],
+        "summary": "Edits a release.",
+        "description": "Required permissions: Processes.Edit.",
+        "operationId": "Releases_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "ReleaseDto",
+            "in": "body",
+            "description": "The entity to put",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReleaseDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ReleaseDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Releases"
+        ],
+        "summary": "Deletes a release.",
+        "description": "Required permissions: Processes.Delete.",
+        "operationId": "Releases_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      },
+      "patch": {
+        "tags": [
+          "Releases"
+        ],
+        "summary": "Partially updates a release.",
+        "description": "Required permissions: Processes.Edit.",
+        "operationId": "Releases_PatchById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "ReleaseDto",
+            "in": "body",
+            "description": "The entity to patch",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReleaseDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Releases({Id})/UiPath.Server.Configuration.OData.UpdateToSpecificPackageVersion": {
+      "post": {
+        "tags": [
+          "Releases"
+        ],
+        "summary": "Updates the package version for the given release.",
+        "description": "Required permissions: Processes.Edit.",
+        "operationId": "Releases_UpdateToSpecificPackageVersionById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "specificPackageParameters",
+            "in": "body",
+            "description": "PackageVersion - The new package version.",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "packageVersion": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Releases({Id})/UiPath.Server.Configuration.OData.UpdateToLatestPackageVersion": {
+      "post": {
+        "tags": [
+          "Releases"
+        ],
+        "summary": "Updates the package version for the given release to the latest available.",
+        "description": "Required permissions: Processes.Edit.",
+        "operationId": "Releases_UpdateToLatestPackageVersionById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Releases/UiPath.Server.Configuration.OData.UpdateToLatestPackageVersionBulk": {
+      "post": {
+        "tags": [
+          "Releases"
+        ],
+        "summary": "Updates the package versions for the given releases to the latest available.",
+        "description": "Required permissions: Processes.Edit.",
+        "operationId": "Releases_UpdateToLatestPackageVersionBulk",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "updateToLatestBulk",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "required": [
+                "releaseIds"
+              ],
+              "type": "object",
+              "properties": {
+                "releaseIds": {
+                  "type": "array",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/BulkOperationResponseDto[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Releases({Id})/UiPath.Server.Configuration.OData.RollbackToPreviousReleaseVersion": {
+      "post": {
+        "tags": [
+          "Releases"
+        ],
+        "summary": "Reverts the package versions for the given release to the last version it had before the current one.",
+        "description": "Required permissions: Processes.Edit.",
+        "operationId": "Releases_RollbackToPreviousReleaseVersionById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/RobotLogs": {
+      "get": {
+        "tags": [
+          "RobotLogs"
+        ],
+        "summary": "Gets the robot logs.",
+        "description": "Required permissions: Logs.View.",
+        "operationId": "RobotLogs_GetRobotLogs",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[LogDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/RobotLogs/UiPath.Server.Configuration.OData.GetTotalCount()": {
+      "get": {
+        "tags": [
+          "RobotLogs"
+        ],
+        "summary": "Gets the total count of robot logs.\r\nThis might be different than the size of the count returned by GetRobotLogs which\r\nis limited by the max_result_window parameter for an Elasticsearch source.",
+        "description": "Required permissions: Logs.View.",
+        "operationId": "RobotLogs_GetTotalCount",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[Int64]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/RobotLogs/UiPath.Server.Configuration.OData.Reports()": {
+      "get": {
+        "tags": [
+          "RobotLogs"
+        ],
+        "summary": "Reports.",
+        "description": "Required permissions: Logs.View.",
+        "operationId": "RobotLogs_Reports",
+        "consumes": [],
+        "produces": [
+          "image/file"
+        ],
+        "parameters": [
+          {
+            "name": "fileNameSubject",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "format": "file",
+              "type": "file"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Robots": {
+      "get": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Gets robots.",
+        "description": "Required permissions: Robots.View.",
+        "operationId": "Robots_GetRobots",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[RobotDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Creates a new robot.",
+        "description": "Required permissions: (Robots.Create - Floating Robot) and (Robots.Create and Machines.View - Standard Robot).",
+        "operationId": "Robots_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "robotDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RobotDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/RobotDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Robots({Id})": {
+      "get": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Gets a single robot based on its key.",
+        "description": "Required permissions: Robots.View.",
+        "operationId": "Robots_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/RobotDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Edits a robot based on its key.",
+        "description": "Required permissions: Robots.Edit.",
+        "operationId": "Robots_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "robotDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RobotDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/RobotDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Deletes a robot based on its key.",
+        "description": "Required permissions: Robots.Delete.",
+        "operationId": "Robots_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      },
+      "patch": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Partially updates a robot.",
+        "description": "Required permissions: Robots.Edit.",
+        "operationId": "Robots_PatchById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "RobotDto",
+            "in": "body",
+            "description": "The entity to patch",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RobotDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Robots/UiPath.Server.Configuration.OData.GetMachineNameToLicenseKeyMappings()": {
+      "get": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Gets machine name to license key mapping.",
+        "description": "Required permissions: Robots.Create and Machines.View.",
+        "operationId": "Robots_GetMachineNameToLicenseKeyMappings",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[KeyValuePair[String,String]]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Robots/UiPath.Server.Configuration.OData.GetUsernames()": {
+      "get": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Gets usernames.",
+        "description": "Required permissions: Robots.View.",
+        "operationId": "Robots_GetUsernames",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[String]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Robots/UiPath.Server.Configuration.OData.GetRobotsForProcess(processId='{processId}')": {
+      "get": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Returns a collection of all robots that can execute the process with the provided Id.",
+        "description": "Required permissions: Robots.View and Environments.View and Processes.View.",
+        "operationId": "Robots_GetRobotsForProcessByProcessid",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "processId",
+            "in": "path",
+            "description": "The Id of the process for which the robots are fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[RobotDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Robots/UiPath.Server.Configuration.OData.DeleteBulk": {
+      "post": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Deletes multiple robots based on their keys.",
+        "description": "Required permissions: Robots.Delete.",
+        "operationId": "Robots_DeleteBulk",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "robotsDeleteBulk",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "required": [
+                "robotIds"
+              ],
+              "type": "object",
+              "properties": {
+                "robotIds": {
+                  "type": "array",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "Empty robotIds collection in payload"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Robots/UiPath.Server.Configuration.OData.ConvertToFloating": {
+      "post": {
+        "tags": [
+          "Robots"
+        ],
+        "summary": "Convert a Standard Attended Robot to a Floating Robot.",
+        "description": "Required permissions: Robots.Edit.",
+        "operationId": "Robots_ConvertToFloating",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "convertToFloatingParams",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "required": [
+                "robotId"
+              ],
+              "type": "object",
+              "properties": {
+                "robotId": {
+                  "format": "int64",
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "400": {
+            "description": "Invalid arguments"
+          },
+          "409": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Roles": {
+      "get": {
+        "tags": [
+          "Roles"
+        ],
+        "summary": "Gets roles.",
+        "description": "Required permissions: Roles.View.",
+        "operationId": "Roles_GetRoles",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[RoleDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Roles"
+        ],
+        "summary": "Creates a new role.",
+        "description": "Required permissions: Roles.Create.",
+        "operationId": "Roles_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "roleDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RoleDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/RoleDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Roles({Id})": {
+      "get": {
+        "tags": [
+          "Roles"
+        ],
+        "summary": "Gets role based on its id.",
+        "description": "Required permissions: Roles.View.",
+        "operationId": "Roles_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/RoleDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "Roles"
+        ],
+        "summary": "Edits a role.",
+        "description": "Required permissions: Roles.Edit.",
+        "operationId": "Roles_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "roleDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RoleDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/RoleDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Roles"
+        ],
+        "summary": "Deletes a role.",
+        "description": "Required permissions: Roles.Delete.",
+        "operationId": "Roles_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Roles/UiPath.Server.Configuration.OData.GetUsersForRole(key={key})": {
+      "get": {
+        "tags": [
+          "Roles"
+        ],
+        "summary": "Returns a collection of all users and, if no other sorting is provided, will place first those associated to a role. Allows odata query options.",
+        "description": "Required permissions: Roles.View and Users.View.",
+        "operationId": "Roles_GetUsersForRoleByKey",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "The Id of the role for which the associated users are placed first.",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[UserDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Roles/UiPath.Server.Configuration.OData.GetUserIdsForRole(key={key})": {
+      "get": {
+        "tags": [
+          "Roles"
+        ],
+        "summary": "Returns a collection of all the ids of the users associated to a role based on role Id.",
+        "description": "Required permissions: Roles.View or Users.View.",
+        "operationId": "Roles_GetUserIdsForRoleByKey",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "The Id of the role for which the robot ids are fetched.",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[Int64]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Roles({Id})/UiPath.Server.Configuration.OData.SetUsers": {
+      "post": {
+        "tags": [
+          "Roles"
+        ],
+        "summary": "Associates a group of users with and dissociates another group of users from the given role.",
+        "description": "Required permissions: Users.Edit.",
+        "operationId": "Roles_SetUsersById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "setUsersParameters",
+            "in": "body",
+            "description": "<para />addedUserIds - The id of the users to be associated with the role.\r\n            <para />removedUserIds - The id of the users to be dissociated from the role.",
+            "required": true,
+            "schema": {
+              "required": [
+                "addedUserIds",
+                "removedUserIds"
+              ],
+              "type": "object",
+              "properties": {
+                "addedUserIds": {
+                  "type": "array",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "removedUserIds": {
+                  "type": "array",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Nothing returned"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Sessions": {
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Gets the sessions.",
+        "description": "Required permissions: Robots.View.",
+        "operationId": "Sessions_GetSessions",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[SessionDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the settings.",
+        "description": "Required permissions: Settings.View.",
+        "operationId": "Settings_GetSettings",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[SettingsDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings('{Id}')": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets a settings value based on its key.",
+        "description": "Required permissions: Settings.View.",
+        "operationId": "Settings_GetSettingsById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SettingsDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Edits a setting.",
+        "description": "Required permissions: Settings.Edit.",
+        "operationId": "Settings_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "SettingsDto",
+            "in": "body",
+            "description": "The entity to put",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SettingsDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SettingsDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.GetServicesSettings()": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Returns a collection of key value pairs representing all service settings used by a robot. A valid robot license key is required in the request headers.",
+        "operationId": "Settings_GetServicesSettings",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ResponseDictionaryDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.GetWebSettings()": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Returns a collection of key value pairs representing settings used by Orchestrator web client.",
+        "description": "Requires authentication.",
+        "operationId": "Settings_GetWebSettings",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ResponseDictionaryDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.GetAuthenticationSettings()": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the authentication settings",
+        "operationId": "Settings_GetAuthenticationSettings",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ResponseDictionaryDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.GetExecutionSettingsConfiguration(scope={scope})": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the execution settings configuration (display name, value type, etc.).\r\nIf scope is 0 (Global), the default values will be the initial ones. If scope is 1 (Robot), then\r\nthe default values will be the actual values set globally.\r\ne.g., Resolution width\r\nAssume it was set globally to 720.\r\nThen within the config returned by this function, the default value for this setting will be:\r\n- 0 for scope = 0 and\r\n- 720 for scope = 1.",
+        "description": "Required permissions: Settings.Edit or Robots.Create or Robots.Edit.",
+        "operationId": "Settings_GetExecutionSettingsConfigurationByScope",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "Scope of the configuration; 0 for Global, 1 for Robot",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ExecutionSettingsConfiguration"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.GetConnectionString()": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the connection string",
+        "description": "Required permissions: Settings.View.",
+        "operationId": "Settings_GetConnectionString",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.GetLicense()": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Retrieves the current license information.",
+        "description": "Requires authentication.",
+        "operationId": "Settings_GetLicense",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/LicenseDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.UploadLicense": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Uploads a new license file that was previously generated with Regutil. The content of the license is sent as a file embedded in the HTTP request.",
+        "description": "Required permissions: License.Create or License.Edit.",
+        "operationId": "Settings_UploadLicense",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.DeleteLicense": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Removes the license",
+        "description": "Required permissions: License.Delete.",
+        "operationId": "Settings_DeleteLicense",
+        "consumes": [],
+        "produces": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.GetTimezones()": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets timezones.",
+        "operationId": "Settings_GetTimezones",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ListResultDto[NameValueDto]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.UpdateBulk": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Updates the current settings.",
+        "description": "Required permissions: Settings.Edit.",
+        "operationId": "Settings_UpdateBulk",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "updateBulkParameters",
+            "in": "body",
+            "description": "Settings - The collection of settings to be updated.",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "settings": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/SettingsDto"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SettingsDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.GetLanguages()": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets supported languages",
+        "operationId": "Settings_GetLanguages",
+        "consumes": [],
+        "produces": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "object"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.GetCalendar()": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets custom calendar, with excluded dates in UTC, for current tenant",
+        "description": "Required permissions: Settings.View.",
+        "operationId": "Settings_GetCalendar",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/CalendarDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings/UiPath.Server.Configuration.OData.SetCalendar": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Sets custom calendar, with excluded dates in UTC, for current tenant",
+        "description": "Required permissions: Settings.Edit.",
+        "operationId": "Settings_SetCalendar",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "calendar",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CalendarDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Settings('{key}')": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets a settings value based on its key.",
+        "description": "Required permissions: Settings.View.",
+        "operationId": "Settings_GetSettingsByKey",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SettingsDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Tenants": {
+      "get": {
+        "tags": [
+          "Tenants"
+        ],
+        "summary": "Gets tenants.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "Tenants_GetTenants",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[TenantDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Tenants"
+        ],
+        "summary": "Creates a tenant.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "Tenants_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "TenantDto",
+            "in": "body",
+            "description": "The entity to post",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TenantDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/TenantDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Tenants({Id})": {
+      "get": {
+        "tags": [
+          "Tenants"
+        ],
+        "summary": "Gets a single tenant based on its id.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "Tenants_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/TenantDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Tenants"
+        ],
+        "summary": "Deletes a tenant based on its id.",
+        "description": "Host only. Requires authentication.",
+        "operationId": "Tenants_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      },
+      "patch": {
+        "tags": [
+          "Tenants"
+        ],
+        "summary": "Partially updates a tenant",
+        "description": "Host only. Requires authentication.",
+        "operationId": "Tenants_PatchById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "TenantDto",
+            "in": "body",
+            "description": "The entity to patch",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TenantDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Tenants/UiPath.Server.Configuration.OData.SetActive": {
+      "post": {
+        "tags": [
+          "Tenants"
+        ],
+        "summary": "Toggles the active status of tenants",
+        "description": "Host only. Requires authentication.",
+        "operationId": "Tenants_SetActive",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "setActiveParameters",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "required": [
+                "tenantIds",
+                "active"
+              ],
+              "type": "object",
+              "properties": {
+                "tenantIds": {
+                  "type": "array",
+                  "items": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "active": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/UserLoginAttempts({Id})": {
+      "get": {
+        "tags": [
+          "UserLoginAttempts"
+        ],
+        "summary": "Gets the user's login attempts",
+        "description": "Requires authentication.",
+        "operationId": "UserLoginAttempts_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[UserLoginAttemptDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Gets users.",
+        "description": "Required permissions: Users.View.",
+        "operationId": "Users_GetUsers",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[UserDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Creates a new user.",
+        "description": "Required permissions: Users.Create.",
+        "operationId": "Users_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "userDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UserDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UserDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Users({Id})": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Gets a user based on its id.",
+        "description": "Requires authentication.",
+        "operationId": "Users_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UserDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Edits a user.",
+        "description": "Required permissions: Users.Edit.",
+        "operationId": "Users_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "userDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UserDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UserDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Deletes a user.",
+        "description": "Required permissions: Users.Delete.",
+        "operationId": "Users_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      },
+      "patch": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Partially updates a user.\r\nCannot update roles or organization units via this endpoint.",
+        "description": "Requires authentication.",
+        "operationId": "Users_PatchById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "userDto",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UserDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Users/UiPath.Server.Configuration.OData.GetCurrentPermissions()": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Returns a user permission collection containing data about the current user and all the permissions it has.",
+        "description": "Requires authentication.",
+        "operationId": "Users_GetCurrentPermissions",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UserPermissionsCollection"
+            }
+          },
+          "401": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Users/UiPath.Server.Configuration.OData.GetCurrentUser()": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Returns details about the user currently logged into Orchestrator.",
+        "operationId": "Users_GetCurrentUser",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the odata-count header.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UserDto"
+            }
+          },
+          "204": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UserDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Users({Id})/UiPath.Server.Configuration.OData.ToggleRole": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Associates/dissociates the given user with/from a role based on toggle parameter.",
+        "description": "Required permissions: Users.Edit.",
+        "operationId": "Users_ToggleRoleById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "toggleRoleParameters",
+            "in": "body",
+            "description": "<para />Toggle - States whether to associate or to dissociate the role with/from the user.\r\n            <para />Role - The name of the role to be associated/dissociated.",
+            "required": true,
+            "schema": {
+              "required": [
+                "toggle"
+              ],
+              "type": "object",
+              "properties": {
+                "role": {
+                  "type": "string"
+                },
+                "toggle": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Users/UiPath.Server.Configuration.OData.ImportUsers": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Imports from AD all users from the given group and associates them with given roles.",
+        "description": "Required permissions: Users.Create.",
+        "operationId": "Users_ImportUsers",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "importUsersParameters",
+            "in": "body",
+            "description": "<para />Group - The name of the AD group whose users are to be imported.\r\n            <para />RolesList - The collection of roles the imported users will be associated with.\r\n            <para />OrganizationUnitIds - The collection of ids of the organization units the imported users will be associated with.",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "group": {
+                  "type": "string"
+                },
+                "domain": {
+                  "type": "string"
+                },
+                "rolesList": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Users({Id})/UiPath.Server.Configuration.OData.ChangePassword": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Changes the password of the user.",
+        "operationId": "Users_ChangePasswordById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "changePasswordParameters",
+            "in": "body",
+            "description": "<para />CurrentPassword - The current password of the user.\r\n            <para />NewPassword - Then new password of the user.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ChangePasswordDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Users({Id})/UiPath.Server.Configuration.OData.SetActive": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Activate or deactivate a user",
+        "description": "Required permissions: Users.Edit.",
+        "operationId": "Users_SetActiveById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "setUserActiveParameters",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "required": [
+                "active"
+              ],
+              "type": "object",
+              "properties": {
+                "active": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Users/UiPath.Server.Configuration.OData.ChangeCulture": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Changes the culture for the current user",
+        "description": "Requires authentication.",
+        "operationId": "Users_ChangeCulture",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "changeCultureParameters",
+            "in": "body",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "culture": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Users/UiPath.Server.Configuration.OData.UpdatePassword": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Updates the user password for the provided Username and Tenancy Name.\r\nThis endpoint is intended to be used via API to update the first login password.",
+        "operationId": "Users_UpdatePassword",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "updatePasswordParameters",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateUserPasswordDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User password successfully updated."
+          },
+          "400": {
+            "description": "Invalid authentication credentials."
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Webhooks": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "List webhooks",
+        "description": "Required permissions: Webhooks.View.",
+        "operationId": "Webhooks_GetWebhooks",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "Filters the results, based on a Boolean condition.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Sorts the results.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Returns only the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Skips the first n results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Includes a count of the matching results in the response.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[WebhookDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Create a new webhook subscription",
+        "description": "Required permissions: Webhooks.Create.",
+        "operationId": "Webhooks_Post",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "WebhookDto",
+            "in": "body",
+            "description": "The entity to post",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WebhookDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Webhook created",
+            "schema": {
+              "$ref": "#/definitions/WebhookDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Webhooks({Id})": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Gets a single webhook",
+        "description": "Required permissions: Webhooks.View.",
+        "operationId": "Webhooks_GetById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands related entities inline.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Selects which properties to include in the response.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/WebhookDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Update an existing webhook subscription",
+        "description": "Required permissions: Webhooks.Edit.",
+        "operationId": "Webhooks_PutById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "WebhookDto",
+            "in": "body",
+            "description": "The entity to put",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WebhookDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/WebhookDto"
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Delete a webhook subscription",
+        "description": "Required permissions: Webhooks.Delete.",
+        "operationId": "Webhooks_DeleteById",
+        "consumes": [],
+        "produces": [],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "If-Match header",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "deprecated": false
+      },
+      "patch": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Update entity in EntitySet Webhooks",
+        "description": "Required permissions: Webhooks.Edit.",
+        "operationId": "Webhooks_PatchById",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "WebhookDto",
+            "in": "body",
+            "description": "The entity to patch",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WebhookDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/WebhookDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Webhooks({Id})/UiPath.Server.Configuration.OData.Ping": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Sends a Ping request to webhook endpoint. \r\nUsed for testing connectivity and availability of target URL",
+        "description": "Required permissions: Webhooks.View.",
+        "operationId": "Webhooks_PingById",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Id",
+            "in": "path",
+            "description": "key: Id",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/PingEventDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Webhooks/UiPath.Server.Configuration.OData.GetEventTypes()": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Gets the list of event types a webhook can subscribe to",
+        "description": "Required permissions: Webhooks.View.",
+        "operationId": "Webhooks_GetEventTypes",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ODataResponse[List[WebhookEventTypeDto]]"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/odata/Webhooks/UiPath.Server.Configuration.OData.TriggerCustom": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Triggers an event of type \"custom\"",
+        "description": "Required permissions: Webhooks.View.",
+        "operationId": "Webhooks_TriggerCustom",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "eventData",
+            "in": "body",
+            "description": "Any custom event data payload",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AnyObjectDto"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/CustomEventDto"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "ClearCacheModel": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "caches": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AjaxResponse": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "type": "object"
+        },
+        "targetUrl": {
+          "type": "string"
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "error": {
+          "$ref": "#/definitions/ErrorInfo"
+        },
+        "unAuthorizedRequest": {
+          "type": "boolean"
+        },
+        "__abp": {
+          "type": "boolean",
+          "readOnly": true
+        }
+      }
+    },
+    "ErrorInfo": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        },
+        "validationErrors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ValidationErrorInfo"
+          }
+        }
+      }
+    },
+    "ValidationErrorInfo": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ClearAllCacheModel": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "LoginModel": {
+      "required": [
+        "usernameOrEmailAddress",
+        "password"
+      ],
+      "type": "object",
+      "properties": {
+        "tenancyName": {
+          "type": "string"
+        },
+        "usernameOrEmailAddress": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "CancellationToken": {
+      "type": "object",
+      "properties": {
+        "isCancellationRequested": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "canBeCanceled": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "waitHandle": {
+          "$ref": "#/definitions/WaitHandle",
+          "readOnly": true
+        }
+      }
+    },
+    "WaitHandle": {
+      "type": "object",
+      "properties": {
+        "handle": {
+          "type": "object"
+        },
+        "safeWaitHandle": {
+          "$ref": "#/definitions/SafeWaitHandle"
+        }
+      }
+    },
+    "SafeWaitHandle": {
+      "type": "object",
+      "properties": {
+        "isInvalid": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "isClosed": {
+          "type": "boolean",
+          "readOnly": true
+        }
+      }
+    },
+    "HeartbeatPayload": {
+      "type": "object",
+      "properties": {
+        "heartbeats": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HeartbeatDto"
+          }
+        },
+        "serviceUserName": {
+          "type": "string"
+        }
+      }
+    },
+    "HeartbeatDto": {
+      "type": "object",
+      "properties": {
+        "robotKey": {
+          "type": "string"
+        },
+        "robotState": {
+          "enum": [
+            "Available",
+            "Busy",
+            "Disconnected",
+            "Unknown"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "HeartbeatDtoRobotState",
+            "modelAsString": false
+          }
+        },
+        "jobState": {
+          "enum": [
+            "Pending",
+            "Running",
+            "Stopping",
+            "Terminating",
+            "Faulted",
+            "Successful",
+            "Stopped"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "HeartbeatDtoJobState",
+            "modelAsString": false
+          }
+        },
+        "jobKey": {
+          "type": "string"
+        },
+        "processKey": {
+          "type": "string"
+        },
+        "info": {
+          "type": "string"
+        },
+        "outputArguments": {
+          "type": "string"
+        }
+      }
+    },
+    "HeartbeatResponse": {
+      "type": "object",
+      "properties": {
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RobotCommand"
+          }
+        }
+      }
+    },
+    "RobotCommand": {
+      "type": "object",
+      "properties": {
+        "robotKey": {
+          "description": "Target robot",
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "robotName": {
+          "type": "string"
+        },
+        "robotType": {
+          "enum": [
+            "NonProduction",
+            "Attended",
+            "Unattended",
+            "Development"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RobotCommandRobotType",
+            "modelAsString": false
+          }
+        },
+        "machineId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "hasLicense": {
+          "type": "boolean"
+        },
+        "executionSettings": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "data": {
+          "$ref": "#/definitions/Command"
+        }
+      }
+    },
+    "Command": {
+      "description": "Base command model\r\nAll commands must inherit from this",
+      "type": "object",
+      "properties": {
+        "id": {
+          "format": "uuid",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "RobotIdentifier": {
+      "type": "object",
+      "properties": {
+        "robotKey": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string"
+        }
+      }
+    },
+    "PublishedProcess": {
+      "type": "object",
+      "properties": {
+        "activationKey": {
+          "type": "string"
+        },
+        "processName": {
+          "type": "string"
+        },
+        "processKey": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "packageId": {
+          "type": "string"
+        },
+        "packageVersion": {
+          "type": "string"
+        }
+      }
+    },
+    "RobotServicePayload": {
+      "type": "object",
+      "properties": {
+        "serviceUserName": {
+          "type": "string"
+        }
+      }
+    },
+    "RobotServiceResponse": {
+      "type": "object",
+      "properties": {
+        "robots": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RobotDetailsDto"
+          }
+        }
+      }
+    },
+    "RobotDetailsDto": {
+      "type": "object",
+      "properties": {
+        "robotKey": {
+          "description": "The Robot key.",
+          "type": "string"
+        },
+        "user": {
+          "description": "The Robot username.",
+          "type": "string"
+        },
+        "machineName": {
+          "description": "The name of the machine a Robot is hosted on.",
+          "type": "string"
+        },
+        "machineId": {
+          "format": "int64",
+          "description": "The Machine Id.",
+          "type": "integer"
+        },
+        "robotName": {
+          "description": "The Robot name.",
+          "type": "string"
+        },
+        "robotType": {
+          "description": "The Robot type.",
+          "enum": [
+            "NonProduction",
+            "Attended",
+            "Unattended",
+            "Development"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RobotDetailsDtoRobotType",
+            "modelAsString": false
+          }
+        },
+        "hasLicense": {
+          "description": "Whether the Robot is licensed or not",
+          "type": "boolean"
+        },
+        "tenantId": {
+          "format": "int32",
+          "description": "The Tenant's Id.",
+          "type": "integer"
+        },
+        "organizationUnitId": {
+          "format": "int64",
+          "description": "The OrganizationUnit's Id.",
+          "type": "integer"
+        },
+        "executionSettings": {
+          "description": "A collection of key value pairs containing execution settings for this robot.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ConnectionData": {
+      "type": "object",
+      "properties": {
+        "licenseKey": {
+          "type": "string"
+        },
+        "orchestratorUrl": {
+          "type": "string"
+        }
+      }
+    },
+    "CountStats": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "count": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "hasPermissions": {
+          "description": "Gives a more descriptive result when getting stats through the API (as opposed to -1 for the count)\r\nused only when serializing the count stats",
+          "type": "boolean",
+          "readOnly": true
+        }
+      }
+    },
+    "LicenseStatsModel": {
+      "type": "object",
+      "properties": {
+        "robotType": {
+          "enum": [
+            "NonProduction",
+            "Attended",
+            "Unattended",
+            "Development"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "LicenseStatsModelRobotType",
+            "modelAsString": false
+          }
+        },
+        "count": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "timestamp": {
+          "format": "date-time",
+          "type": "string"
+        }
+      }
+    },
+    "HostAvailabilityDto": {
+      "type": "object",
+      "properties": {
+        "canConnect": {
+          "description": "Target host is reachable and a succesful TCP connection could be made on the specified port",
+          "type": "boolean"
+        },
+        "hasBadSsl": {
+          "description": "Any error occurred during SSL/TLS authentication.\r\nIncludes bad certificates (name mismatch, expired certificates), unsupported protocol versions or cyphersuites",
+          "type": "boolean"
+        },
+        "connectionError": {
+          "description": "An error code that further describes the type of connection error.\r\nDoes not include TLS/SSL errors",
+          "type": "string"
+        }
+      }
+    },
+    "PingEventDto": {
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "ping"
+    },
+    "CustomEventDto": {
+      "description": "An event triggered by a robot Orchestrator activity",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "EventData": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "CustomEventDto"
+    },
+    "AnyObjectDto": {
+      "type": "object",
+      "properties": {}
+    },
+    "JobCompletedEventDto": {
+      "description": "This event is raised whenever a job has completed successfully",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Job": {
+          "$ref": "#/definitions/WebhookSimpleJobDto"
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "job.completed"
+    },
+    "WebhookSimpleJobDto": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Key": {
+          "format": "uuid",
+          "type": "string",
+          "readOnly": true
+        },
+        "State": {
+          "enum": [
+            "Pending",
+            "Running",
+            "Stopping",
+            "Terminating",
+            "Faulted",
+            "Successful",
+            "Stopped"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookSimpleJobDtoState",
+            "modelAsString": false
+          }
+        },
+        "StartTime": {
+          "format": "date-time",
+          "type": "string",
+          "readOnly": true
+        },
+        "EndTime": {
+          "format": "date-time",
+          "type": "string",
+          "readOnly": true
+        },
+        "Info": {
+          "type": "string",
+          "readOnly": true
+        },
+        "OutputArguments": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Robot": {
+          "$ref": "#/definitions/WebhookSimpleRobotDto",
+          "readOnly": true
+        },
+        "Release": {
+          "$ref": "#/definitions/WebhookSimpleReleaseDto",
+          "readOnly": true
+        }
+      }
+    },
+    "WebhookSimpleRobotDto": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "MachineName": {
+          "type": "string"
+        }
+      }
+    },
+    "WebhookSimpleReleaseDto": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "description": "The Id of the process",
+          "type": "integer"
+        },
+        "Key": {
+          "description": "The unique key of the process",
+          "type": "string"
+        },
+        "ProcessKey": {
+          "description": "The name of the process",
+          "type": "string"
+        }
+      }
+    },
+    "JobFaultedEventDto": {
+      "description": "This event is raised whenever a job has failed to finish execution",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Job": {
+          "$ref": "#/definitions/WebhookSimpleJobDto"
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "job.faulted"
+    },
+    "JobsCreatedEventDto": {
+      "description": "This event is raised whenever jobs were created and queued for execution",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "StartInfo": {
+          "$ref": "#/definitions/WebhookStartProcessDto",
+          "description": "List of arguments used to create the jobs"
+        },
+        "Jobs": {
+          "description": "List of jobs that were created and are in pending state",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookJobDto"
+          },
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "job.created"
+    },
+    "WebhookStartProcessDto": {
+      "type": "object",
+      "properties": {
+        "ReleaseKey": {
+          "format": "uuid",
+          "description": "The unique key of the release associated with the process.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Strategy": {
+          "description": "States which robots from the environment are being run by the process.",
+          "enum": [
+            "All",
+            "Specific",
+            "RobotCount",
+            "JobsCount"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookStartProcessDtoStrategy",
+            "modelAsString": false
+          }
+        },
+        "RobotIds": {
+          "description": "The collection of ids of specific robots selected to be run by the current process. This collection must be empty only if the start strategy is not Specific.",
+          "type": "array",
+          "items": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "readOnly": true
+        },
+        "JobsCount": {
+          "format": "int32",
+          "description": "Number of pending jobs to be created in the environment, for the current process. This number must be greater than 0 only if the start strategy is JobsCount.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Source": {
+          "description": "The Source of the job starting the current process.",
+          "enum": [
+            "Manual",
+            "Schedule"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookStartProcessDtoSource",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "WebhookJobDto": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Key": {
+          "format": "uuid",
+          "description": "The unique job identifier.",
+          "type": "string",
+          "readOnly": true
+        },
+        "StartTime": {
+          "format": "date-time",
+          "description": "The date and time when the job execution started or null if the job hasn't started yet.",
+          "type": "string",
+          "readOnly": true
+        },
+        "EndTime": {
+          "format": "date-time",
+          "description": "The date and time when the job execution ended or null if the job hasn't ended yet.",
+          "type": "string",
+          "readOnly": true
+        },
+        "State": {
+          "description": "The state in which the job is.",
+          "enum": [
+            "Pending",
+            "Running",
+            "Stopping",
+            "Terminating",
+            "Faulted",
+            "Successful",
+            "Stopped"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookJobDtoState",
+            "modelAsString": false
+          }
+        },
+        "Source": {
+          "description": "The Source name of the job.",
+          "type": "string",
+          "readOnly": true
+        },
+        "SourceType": {
+          "description": "The Source type of the job.",
+          "enum": [
+            "Manual",
+            "Schedule",
+            "Agent"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookJobDtoSourceType",
+            "modelAsString": false
+          }
+        },
+        "BatchExecutionKey": {
+          "format": "uuid",
+          "description": "The unique identifier grouping multiple jobs. It is usually generated when the job is created by a schedule.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Info": {
+          "description": "Additional information about the current job.",
+          "type": "string",
+          "readOnly": true
+        },
+        "StartingScheduleId": {
+          "format": "int64",
+          "description": "The Id of the schedule that started the job, or null if the job was started by the user.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "ReleaseName": {
+          "description": "The name of the release associated with the current name.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Type": {
+          "description": "The type of the job, Attended if started via the robot, Unattended otherwise",
+          "enum": [
+            "Unattended",
+            "Attended"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookJobDtoType",
+            "modelAsString": false
+          }
+        },
+        "HostMachineName": {
+          "description": "The name of the machine where the Robot run the job.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Robot": {
+          "$ref": "#/definitions/WebhookRobotDto",
+          "description": "The robot associated with the current job.",
+          "readOnly": true
+        },
+        "Release": {
+          "$ref": "#/definitions/WebhookReleaseDto",
+          "description": "The release associated with the current job.",
+          "readOnly": true
+        },
+        "InputArguments": {
+          "description": "Input parameters in JSON format to be passed to job execution",
+          "type": "object",
+          "readOnly": true
+        },
+        "OutputArguments": {
+          "description": "Output parameters in JSON format resulted from job execution",
+          "type": "object",
+          "readOnly": true
+        }
+      }
+    },
+    "WebhookRobotDto": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "MachineId": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "MachineName": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Description": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Version": {
+          "type": "string",
+          "readOnly": true
+        },
+        "UserName": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Type": {
+          "enum": [
+            "NonProduction",
+            "Attended",
+            "Unattended",
+            "Development"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookRobotDtoType",
+            "modelAsString": false
+          }
+        },
+        "HostingType": {
+          "enum": [
+            "Standard",
+            "Floating"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookRobotDtoHostingType",
+            "modelAsString": false
+          }
+        },
+        "Environments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookEnvironmentDto"
+          },
+          "readOnly": true
+        },
+        "ExecutionSettings": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "WebhookReleaseDto": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Key": {
+          "type": "string",
+          "readOnly": true
+        },
+        "ProcessKey": {
+          "type": "string",
+          "readOnly": true
+        },
+        "ProcessVersion": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Description": {
+          "type": "string",
+          "readOnly": true
+        },
+        "IsLatestVersion": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "Environment": {
+          "$ref": "#/definitions/WebhookEnvironmentDto",
+          "readOnly": true
+        },
+        "InputArguments": {
+          "type": "object",
+          "readOnly": true
+        }
+      }
+    },
+    "WebhookEnvironmentDto": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Description": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "JobsStoppedEventDto": {
+      "description": "This event is raised whenever jobs were stopped",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Jobs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookSimpleJobDto"
+          }
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "job.stopped"
+    },
+    "JobStartedEventDto": {
+      "description": "This event is raised whenever a job has started execution on a robot",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Job": {
+          "$ref": "#/definitions/WebhookSimpleJobDto"
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "job.started"
+    },
+    "ProcessScheduleFailedEventDto": {
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "ProcessSchedule": {
+          "$ref": "#/definitions/WebhookProcessScheduleDto",
+          "readOnly": true
+        },
+        "Reason": {
+          "type": "string",
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "schedule.failed"
+    },
+    "WebhookProcessScheduleDto": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Name": {
+          "description": "The name of the schedule.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Enabled": {
+          "description": "Specifies if the schedule is active or not.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "EnvironmentId": {
+          "description": "The Id of the environment associated with the schedule.",
+          "type": "string",
+          "readOnly": true
+        },
+        "EnvironmentName": {
+          "description": "The name of the environment associated with the schedule.",
+          "type": "string",
+          "readOnly": true
+        },
+        "StartProcessCron": {
+          "description": "The start cron expression of the schedule.",
+          "type": "string",
+          "readOnly": true
+        },
+        "StartStrategy": {
+          "description": "States which robots from the environment are being run by the schedule.",
+          "enum": [
+            "All",
+            "Specific",
+            "RobotCount",
+            "JobsCount"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookProcessScheduleDtoStartStrategy",
+            "modelAsString": false
+          }
+        },
+        "StopStrategy": {
+          "description": "The way a running process is stopped.",
+          "enum": [
+            "SoftStop",
+            "Kill"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookProcessScheduleDtoStopStrategy",
+            "modelAsString": false
+          }
+        },
+        "ExternalJobKey": {
+          "description": "The unique identifier of the external job associated with the jobs generated by this schedule. A key is generated for each group of jobs triggered by this schedule.",
+          "type": "string",
+          "readOnly": true
+        },
+        "TimeZoneId": {
+          "description": "The timezone under which the schedule will run.",
+          "type": "string",
+          "readOnly": true
+        },
+        "TimeZoneIana": {
+          "description": "The timezone under which the schedule will run in Iana Standard.",
+          "type": "string",
+          "readOnly": true
+        },
+        "UseCalendar": {
+          "description": "Specify whether the schedule uses the bank holiday calendar",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "Release": {
+          "$ref": "#/definitions/WebhookSimpleReleaseDto",
+          "description": "Process details associated with the schedule",
+          "readOnly": true
+        },
+        "ExecutorRobots": {
+          "description": "The collection of specific robots selected to be targeted by the current schedule. This collection must be empty if the start strategy is not 0 (specific robots).",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookSimpleRobotDto"
+          },
+          "readOnly": true
+        },
+        "InputArguments": {
+          "description": "Input parameters that will be passed to each job created by this schedule.",
+          "type": "object",
+          "readOnly": true
+        }
+      }
+    },
+    "QueueCreatedEventDto": {
+      "description": "This event is raised whenever queue definitions were created",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Queues": {
+          "description": "The queue that triggered the event",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookQueueDefinitionDto"
+          }
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "queue.created"
+    },
+    "WebhookQueueDefinitionDto": {
+      "description": "The definition of a work queue. A work queue contains work items that are processed by robots.",
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Name": {
+          "description": "A custom name for the queue.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Description": {
+          "description": "Used to add additional information about a queue in order to better identify it.",
+          "type": "string",
+          "readOnly": true
+        },
+        "MaxNumberOfRetries": {
+          "format": "int32",
+          "description": "An integer value representing the number of times an item of this queue can be retried if its processing fails with application exception and auto retry is on.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "AcceptAutomaticallyRetry": {
+          "description": "States whether a robot should retry to process an item if, after processing, it failed with application exception.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "EnforceUniqueReference": {
+          "description": "States whether Item Reference field should be unique per Queue. Deleted and retried items are not checked against this rule.",
+          "type": "boolean",
+          "readOnly": true
+        }
+      }
+    },
+    "QueueDeletedEventDto": {
+      "description": "This event is raised whenever queue definitions were deleted",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Queues": {
+          "description": "The queue that triggered the event",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookQueueDefinitionDto"
+          }
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "queue.deleted"
+    },
+    "QueueItemAddedEventDto": {
+      "description": "This event is raised whenever new queue items were added",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Queue": {
+          "$ref": "#/definitions/WebhookQueueDefinitionDto",
+          "readOnly": true
+        },
+        "QueueItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookQueueItemDto"
+          },
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "queueItem.added"
+    },
+    "WebhookQueueItemDto": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Key": {
+          "format": "uuid",
+          "description": "The unique identifier of a queue item.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Reference": {
+          "description": "An optional, user-specified value for queue item identification.",
+          "type": "string",
+          "readOnly": true
+        },
+        "QueueDefinitionId": {
+          "format": "int64",
+          "description": "The Id of the parent queue.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Status": {
+          "description": "The processing state of the item.",
+          "enum": [
+            "New",
+            "InProgress",
+            "Failed",
+            "Successful",
+            "Abandoned",
+            "Retried",
+            "Deleted"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookQueueItemDtoStatus",
+            "modelAsString": false
+          }
+        },
+        "ReviewStatus": {
+          "description": "The review state of the item - applicable only for failed items.",
+          "enum": [
+            "None",
+            "InReview",
+            "Verified",
+            "Retried"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookQueueItemDtoReviewStatus",
+            "modelAsString": false
+          }
+        },
+        "ProcessingException": {
+          "$ref": "#/definitions/WebhookProcessingExceptionDto",
+          "description": "Stores the actual processing exception, if any.",
+          "readOnly": true
+        },
+        "DueDate": {
+          "format": "date-time",
+          "description": "The latest date and time at which the item should be processed. If empty the item can be processed at any given time.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Priority": {
+          "description": "Sets the processing importance for a given item.",
+          "enum": [
+            "High",
+            "Normal",
+            "Low"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookQueueItemDtoPriority",
+            "modelAsString": false
+          }
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the item was created.",
+          "type": "string",
+          "readOnly": true
+        },
+        "DeferDate": {
+          "format": "date-time",
+          "description": "The earliest date and time at which the item is available for processing. If empty the item can be processed as soon as possible.",
+          "type": "string",
+          "readOnly": true
+        },
+        "StartProcessing": {
+          "format": "date-time",
+          "description": "The date and time at which the item processing started. This is null if the item was not processed.",
+          "type": "string",
+          "readOnly": true
+        },
+        "EndProcessing": {
+          "format": "date-time",
+          "description": "The date and time at which the item processing ended. This is null if the item was not processed.",
+          "type": "string",
+          "readOnly": true
+        },
+        "SecondsInPreviousAttempts": {
+          "format": "int32",
+          "description": "The number of seconds that the last failed processing lasted.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "AncestorId": {
+          "format": "int64",
+          "description": "The Id of an ancestor item connected to the current item.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "RetryNumber": {
+          "format": "int32",
+          "description": "The number of times this work item has been processed.\r\n<para />This can be higher than 0 only if MaxRetried number is set and the item processing failed at least once with ApplicationException.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Progress": {
+          "description": "String field which is used to keep track of the business flow progress.",
+          "type": "string",
+          "readOnly": true
+        },
+        "ReviewerUserId": {
+          "format": "int64",
+          "description": "The UserId of the Reviewer, if any.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Robot": {
+          "$ref": "#/definitions/WebhookRobotDto",
+          "description": "The robot that has processed the item, if any.",
+          "readOnly": true
+        },
+        "ReviewerUser": {
+          "$ref": "#/definitions/WebhookSimpleUserDto",
+          "description": "Stores the actual reviewer user, if any.",
+          "readOnly": true
+        },
+        "SpecificContent": {
+          "description": "A collection of key value pairs containing custom data configured in the Add Queue Item activity, in UiPath Studio.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true
+        },
+        "Output": {
+          "description": "A collection of key value pairs containing custom data resulted after successful processing.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "WebhookProcessingExceptionDto": {
+      "type": "object",
+      "properties": {
+        "Reason": {
+          "description": "The reason the processing failed.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Details": {
+          "description": "Stores additional details about the exception.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Type": {
+          "description": "The processing exception type, if any.",
+          "enum": [
+            "ApplicationException",
+            "BusinessException"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookProcessingExceptionDtoType",
+            "modelAsString": false
+          }
+        },
+        "AssociatedImageFilePath": {
+          "description": "A path on the robot running computer to an image file that stores relevant information about the exception - e.g. a system print screen.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "WebhookSimpleUserDto": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "UserName": {
+          "description": "The name used to login to Orchestrator.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Domain": {
+          "description": "The domain from which the user is imported",
+          "type": "string",
+          "readOnly": true
+        },
+        "FullName": {
+          "description": "The full name of the person constructed with the format Name Surname.",
+          "type": "string",
+          "readOnly": true
+        },
+        "EmailAddress": {
+          "description": "The e-mail address associated with the user.",
+          "type": "string",
+          "readOnly": true
+        },
+        "Type": {
+          "description": "The user type.",
+          "enum": [
+            "User",
+            "Robot"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookSimpleUserDtoType",
+            "modelAsString": false
+          }
+        },
+        "IsActive": {
+          "description": "States if the user is active or not. An inactive user cannot login to Orchestrator.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "LastLoginTime": {
+          "format": "date-time",
+          "description": "The date and time when the user last logged in, or null if the user never logged in.",
+          "type": "string",
+          "readOnly": true
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the user was created.",
+          "type": "string",
+          "readOnly": true
+        },
+        "AuthenticationSource": {
+          "description": "The source which authenticated this user.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "QueueItemCompletedEventDto": {
+      "description": "This event is raised whenever a queue item transaction has completed successfully",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "QueueItem": {
+          "$ref": "#/definitions/WebhookQueueItemDto",
+          "readOnly": true
+        },
+        "Queue": {
+          "$ref": "#/definitions/WebhookQueueDefinitionDto",
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "queueItem.transactionCompleted"
+    },
+    "QueueItemFailedEventDto": {
+      "description": "This event is raised whenever a queue item transaction has failed",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "QueueItem": {
+          "$ref": "#/definitions/WebhookQueueItemDto",
+          "readOnly": true
+        },
+        "Queue": {
+          "$ref": "#/definitions/WebhookQueueDefinitionDto",
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "queueItem.transactionFailed"
+    },
+    "QueueItemsAbandonedEventDto": {
+      "description": "This event is raised whenever queue item transactions have expired and were abandoned",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Queue": {
+          "$ref": "#/definitions/WebhookQueueDefinitionDto",
+          "readOnly": true
+        },
+        "QueueItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookQueueItemDto"
+          },
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "queueItem.transactionAbandoned"
+    },
+    "QueueItemStartedEventDto": {
+      "description": "This event is raised whenever a new queue item transaction is started",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "QueueItem": {
+          "$ref": "#/definitions/WebhookQueueItemDto",
+          "readOnly": true
+        },
+        "Queue": {
+          "$ref": "#/definitions/WebhookQueueDefinitionDto",
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "queueItem.transactionStarted"
+    },
+    "QueueUpdatedEventDto": {
+      "description": "This event is raised whenever queue definitions were updated",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Queues": {
+          "description": "The queue that triggered the event",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookQueueDefinitionDto"
+          }
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "queue.updated"
+    },
+    "ReleaseCreatedEventDto": {
+      "description": "This event is raised whenever a new release has been created",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Releases": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookReleaseDto"
+          },
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "process.created"
+    },
+    "ReleaseDeletedEventDto": {
+      "description": "This event is raised whenever a release has been deleted",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Releases": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookReleaseDto"
+          },
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "process.deleted"
+    },
+    "ReleaseUpdatedEventDto": {
+      "description": "This event is raised whenever a release has been updated",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Releases": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookReleaseDto"
+          },
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "process.updated"
+    },
+    "RobotCreatedEventDto": {
+      "description": "This event is raised whenever robots were created",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Robots": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookRobotDto"
+          },
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "robot.created"
+    },
+    "RobotDeletedEventDto": {
+      "description": "This event is raised whenever robots were deleted",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Robots": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookRobotDto"
+          },
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "robot.deleted"
+    },
+    "RobotUpdatedEventDto": {
+      "description": "This event is raised whenever robots were updated",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Robots": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookRobotDto"
+          },
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "robot.updated"
+    },
+    "SessionEventDto": {
+      "description": "This event is raised whenever robot's session has changed",
+      "required": [
+        "Type",
+        "EventId",
+        "Timestamp"
+      ],
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string"
+        },
+        "EventId": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "Sessions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookSessionDto"
+          },
+          "readOnly": true
+        },
+        "TenantId": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "OrganizationUnitId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "x-webhook-event": "robot.status"
+    },
+    "WebhookSessionDto": {
+      "type": "object",
+      "properties": {
+        "SessionId": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "RobotId": {
+          "format": "int64",
+          "type": "integer",
+          "readOnly": true
+        },
+        "HostMachineName": {
+          "type": "string",
+          "readOnly": true
+        },
+        "State": {
+          "enum": [
+            "Available",
+            "Busy",
+            "Disconnected",
+            "Unknown"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookSessionDtoState",
+            "modelAsString": false
+          }
+        },
+        "ReportingTime": {
+          "format": "date-time",
+          "type": "string",
+          "readOnly": true
+        },
+        "IsUnresponsive": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "LicenseErrorCode": {
+          "enum": [
+            "NoLicense",
+            "LicenseExpired",
+            "LicenseUnregistered",
+            "NoAvailableLicenses",
+            "NotEnoughAvailableSlots",
+            "NotEnoughRuntimeLicenses",
+            "LicenseIsAlreadyInUse",
+            "InvalidRequest",
+            "SlotsExceedLicenseLimit",
+            "RuntimeDisabled"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "WebhookSessionDtoLicenseErrorCode",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "ODataQueryOptions[AlertDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataQueryContext": {
+      "type": "object",
+      "properties": {
+        "DefaultQuerySettings": {
+          "$ref": "#/definitions/DefaultQuerySettings",
+          "readOnly": true
+        },
+        "Model": {
+          "$ref": "#/definitions/IEdmModel",
+          "readOnly": true
+        },
+        "ElementType": {
+          "$ref": "#/definitions/IEdmType",
+          "readOnly": true
+        },
+        "NavigationSource": {
+          "$ref": "#/definitions/IEdmNavigationSource",
+          "readOnly": true
+        },
+        "ElementClrType": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Path": {
+          "$ref": "#/definitions/ODataPath",
+          "readOnly": true
+        },
+        "RequestContainer": {
+          "$ref": "#/definitions/IServiceProvider",
+          "readOnly": true
+        }
+      }
+    },
+    "ODataRawQueryOptions": {
+      "type": "object",
+      "properties": {
+        "Filter": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Apply": {
+          "type": "string",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Top": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Skip": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Select": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Expand": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Count": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Format": {
+          "type": "string",
+          "readOnly": true
+        },
+        "SkipToken": {
+          "type": "string",
+          "readOnly": true
+        },
+        "DeltaToken": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "SelectExpandQueryOption": {
+      "type": "object",
+      "properties": {
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "RawSelect": {
+          "type": "string",
+          "readOnly": true
+        },
+        "RawExpand": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/SelectExpandQueryValidator"
+        },
+        "SelectExpandClause": {
+          "$ref": "#/definitions/SelectExpandClause",
+          "readOnly": true
+        },
+        "LevelsMaxLiteralExpansionDepth": {
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "ApplyQueryOption": {
+      "type": "object",
+      "properties": {
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "ResultClrType": {
+          "type": "string",
+          "readOnly": true
+        },
+        "ApplyClause": {
+          "$ref": "#/definitions/ApplyClause",
+          "readOnly": true
+        },
+        "RawValue": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "FilterQueryOption": {
+      "type": "object",
+      "properties": {
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/FilterQueryValidator"
+        },
+        "FilterClause": {
+          "$ref": "#/definitions/FilterClause",
+          "readOnly": true
+        },
+        "RawValue": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "OrderByQueryOption": {
+      "type": "object",
+      "properties": {
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "OrderByNodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OrderByNode"
+          },
+          "readOnly": true
+        },
+        "RawValue": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/OrderByQueryValidator"
+        },
+        "OrderByClause": {
+          "$ref": "#/definitions/OrderByClause",
+          "readOnly": true
+        }
+      }
+    },
+    "SkipQueryOption": {
+      "type": "object",
+      "properties": {
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "RawValue": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Value": {
+          "format": "int32",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/SkipQueryValidator"
+        }
+      }
+    },
+    "TopQueryOption": {
+      "type": "object",
+      "properties": {
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "RawValue": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Value": {
+          "format": "int32",
+          "type": "integer",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/TopQueryValidator"
+        }
+      }
+    },
+    "CountQueryOption": {
+      "type": "object",
+      "properties": {
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "RawValue": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Value": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/CountQueryValidator"
+        }
+      }
+    },
+    "ODataQueryValidator": {
+      "type": "object",
+      "properties": {}
+    },
+    "DefaultQuerySettings": {
+      "type": "object",
+      "properties": {
+        "EnableExpand": {
+          "type": "boolean"
+        },
+        "EnableSelect": {
+          "type": "boolean"
+        },
+        "EnableCount": {
+          "type": "boolean"
+        },
+        "EnableOrderBy": {
+          "type": "boolean"
+        },
+        "EnableFilter": {
+          "type": "boolean"
+        },
+        "MaxTop": {
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "IEdmModel": {
+      "type": "object",
+      "properties": {
+        "SchemaElements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IEdmSchemaElement"
+          },
+          "readOnly": true
+        },
+        "VocabularyAnnotations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IEdmVocabularyAnnotation"
+          },
+          "readOnly": true
+        },
+        "ReferencedModels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IEdmModel"
+          },
+          "readOnly": true
+        },
+        "DeclaredNamespaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "DirectValueAnnotationsManager": {
+          "$ref": "#/definitions/IEdmDirectValueAnnotationsManager",
+          "readOnly": true
+        },
+        "EntityContainer": {
+          "$ref": "#/definitions/IEdmEntityContainer",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmType": {
+      "type": "object",
+      "properties": {
+        "TypeKind": {
+          "enum": [
+            "None",
+            "Primitive",
+            "Entity",
+            "Complex",
+            "Collection",
+            "EntityReference",
+            "Enum",
+            "TypeDefinition",
+            "Untyped",
+            "Path"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmTypeTypeKind",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "IEdmNavigationSource": {
+      "type": "object",
+      "properties": {
+        "NavigationPropertyBindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IEdmNavigationPropertyBinding"
+          },
+          "readOnly": true
+        },
+        "Path": {
+          "$ref": "#/definitions/IEdmPathExpression",
+          "readOnly": true
+        },
+        "Type": {
+          "$ref": "#/definitions/IEdmType",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ODataPath": {
+      "type": "object",
+      "properties": {
+        "EdmType": {
+          "$ref": "#/definitions/IEdmType",
+          "readOnly": true
+        },
+        "NavigationSource": {
+          "$ref": "#/definitions/IEdmNavigationSource",
+          "readOnly": true
+        },
+        "Segments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ODataPathSegment"
+          },
+          "readOnly": true
+        },
+        "PathTemplate": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IServiceProvider": {
+      "type": "object",
+      "properties": {}
+    },
+    "SelectExpandQueryValidator": {
+      "type": "object",
+      "properties": {}
+    },
+    "SelectExpandClause": {
+      "type": "object",
+      "properties": {
+        "SelectedItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SelectItem"
+          },
+          "readOnly": true
+        },
+        "AllSelected": {
+          "type": "boolean",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplyClause": {
+      "type": "object",
+      "properties": {
+        "Transformations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TransformationNode"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "FilterQueryValidator": {
+      "type": "object",
+      "properties": {}
+    },
+    "FilterClause": {
+      "type": "object",
+      "properties": {
+        "Expression": {
+          "$ref": "#/definitions/SingleValueNode",
+          "readOnly": true
+        },
+        "RangeVariable": {
+          "$ref": "#/definitions/RangeVariable",
+          "readOnly": true
+        },
+        "ItemType": {
+          "$ref": "#/definitions/IEdmTypeReference",
+          "readOnly": true
+        }
+      }
+    },
+    "OrderByNode": {
+      "type": "object",
+      "properties": {
+        "Direction": {
+          "enum": [
+            "Ascending",
+            "Descending"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "OrderByNodeDirection",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "OrderByQueryValidator": {
+      "type": "object",
+      "properties": {}
+    },
+    "OrderByClause": {
+      "type": "object",
+      "properties": {
+        "ThenBy": {
+          "$ref": "#/definitions/OrderByClause",
+          "readOnly": true
+        },
+        "Expression": {
+          "$ref": "#/definitions/SingleValueNode",
+          "readOnly": true
+        },
+        "Direction": {
+          "enum": [
+            "Ascending",
+            "Descending"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "OrderByClauseDirection",
+            "modelAsString": false
+          }
+        },
+        "RangeVariable": {
+          "$ref": "#/definitions/RangeVariable",
+          "readOnly": true
+        },
+        "ItemType": {
+          "$ref": "#/definitions/IEdmTypeReference",
+          "readOnly": true
+        }
+      }
+    },
+    "SkipQueryValidator": {
+      "type": "object",
+      "properties": {}
+    },
+    "TopQueryValidator": {
+      "type": "object",
+      "properties": {}
+    },
+    "CountQueryValidator": {
+      "type": "object",
+      "properties": {}
+    },
+    "IEdmSchemaElement": {
+      "type": "object",
+      "properties": {
+        "SchemaElementKind": {
+          "enum": [
+            "None",
+            "TypeDefinition",
+            "Term",
+            "Action",
+            "EntityContainer",
+            "Function"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmSchemaElementSchemaElementKind",
+            "modelAsString": false
+          }
+        },
+        "Namespace": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmVocabularyAnnotation": {
+      "type": "object",
+      "properties": {
+        "Qualifier": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Term": {
+          "$ref": "#/definitions/IEdmTerm",
+          "readOnly": true
+        },
+        "Target": {
+          "$ref": "#/definitions/IEdmVocabularyAnnotatable",
+          "readOnly": true
+        },
+        "Value": {
+          "$ref": "#/definitions/IEdmExpression",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmDirectValueAnnotationsManager": {
+      "type": "object",
+      "properties": {}
+    },
+    "IEdmEntityContainer": {
+      "type": "object",
+      "properties": {
+        "Elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IEdmEntityContainerElement"
+          },
+          "readOnly": true
+        },
+        "SchemaElementKind": {
+          "enum": [
+            "None",
+            "TypeDefinition",
+            "Term",
+            "Action",
+            "EntityContainer",
+            "Function"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmEntityContainerSchemaElementKind",
+            "modelAsString": false
+          }
+        },
+        "Namespace": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmNavigationPropertyBinding": {
+      "type": "object",
+      "properties": {
+        "NavigationProperty": {
+          "$ref": "#/definitions/IEdmNavigationProperty",
+          "readOnly": true
+        },
+        "Target": {
+          "$ref": "#/definitions/IEdmNavigationSource",
+          "readOnly": true
+        },
+        "Path": {
+          "$ref": "#/definitions/IEdmPathExpression",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmPathExpression": {
+      "type": "object",
+      "properties": {
+        "PathSegments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "Path": {
+          "type": "string",
+          "readOnly": true
+        },
+        "ExpressionKind": {
+          "enum": [
+            "None",
+            "BinaryConstant",
+            "BooleanConstant",
+            "DateTimeOffsetConstant",
+            "DecimalConstant",
+            "FloatingConstant",
+            "GuidConstant",
+            "IntegerConstant",
+            "StringConstant",
+            "DurationConstant",
+            "Null",
+            "Record",
+            "Collection",
+            "Path",
+            "If",
+            "Cast",
+            "IsType",
+            "FunctionApplication",
+            "LabeledExpressionReference",
+            "Labeled",
+            "PropertyPath",
+            "NavigationPropertyPath",
+            "DateConstant",
+            "TimeOfDayConstant",
+            "EnumMember",
+            "AnnotationPath"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmPathExpressionExpressionKind",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "ODataPathSegment": {
+      "type": "object",
+      "properties": {
+        "EdmType": {
+          "$ref": "#/definitions/IEdmType",
+          "readOnly": true
+        },
+        "Identifier": {
+          "type": "string"
+        }
+      }
+    },
+    "SelectItem": {
+      "type": "object",
+      "properties": {}
+    },
+    "TransformationNode": {
+      "type": "object",
+      "properties": {
+        "Kind": {
+          "enum": [
+            "Aggregate",
+            "GroupBy",
+            "Filter",
+            "Compute"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "TransformationNodeKind",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "SingleValueNode": {
+      "type": "object",
+      "properties": {
+        "TypeReference": {
+          "$ref": "#/definitions/IEdmTypeReference",
+          "readOnly": true
+        },
+        "Kind": {
+          "enum": [
+            "None",
+            "Constant",
+            "Convert",
+            "NonResourceRangeVariableReference",
+            "BinaryOperator",
+            "UnaryOperator",
+            "SingleValuePropertyAccess",
+            "CollectionPropertyAccess",
+            "SingleValueFunctionCall",
+            "Any",
+            "CollectionNavigationNode",
+            "SingleNavigationNode",
+            "SingleValueOpenPropertyAccess",
+            "SingleResourceCast",
+            "All",
+            "CollectionResourceCast",
+            "ResourceRangeVariableReference",
+            "SingleResourceFunctionCall",
+            "CollectionFunctionCall",
+            "CollectionResourceFunctionCall",
+            "NamedFunctionParameter",
+            "ParameterAlias",
+            "EntitySet",
+            "KeyLookup",
+            "SearchTerm",
+            "CollectionOpenPropertyAccess",
+            "CollectionComplexNode",
+            "SingleComplexNode",
+            "Count",
+            "SingleValueCast"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "SingleValueNodeKind",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "RangeVariable": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "TypeReference": {
+          "$ref": "#/definitions/IEdmTypeReference",
+          "readOnly": true
+        },
+        "Kind": {
+          "format": "int32",
+          "type": "integer",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmTypeReference": {
+      "type": "object",
+      "properties": {
+        "IsNullable": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "Definition": {
+          "$ref": "#/definitions/IEdmType",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmTerm": {
+      "type": "object",
+      "properties": {
+        "Type": {
+          "$ref": "#/definitions/IEdmTypeReference",
+          "readOnly": true
+        },
+        "AppliesTo": {
+          "type": "string",
+          "readOnly": true
+        },
+        "DefaultValue": {
+          "type": "string",
+          "readOnly": true
+        },
+        "SchemaElementKind": {
+          "enum": [
+            "None",
+            "TypeDefinition",
+            "Term",
+            "Action",
+            "EntityContainer",
+            "Function"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmTermSchemaElementKind",
+            "modelAsString": false
+          }
+        },
+        "Namespace": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmVocabularyAnnotatable": {
+      "type": "object",
+      "properties": {}
+    },
+    "IEdmExpression": {
+      "type": "object",
+      "properties": {
+        "ExpressionKind": {
+          "enum": [
+            "None",
+            "BinaryConstant",
+            "BooleanConstant",
+            "DateTimeOffsetConstant",
+            "DecimalConstant",
+            "FloatingConstant",
+            "GuidConstant",
+            "IntegerConstant",
+            "StringConstant",
+            "DurationConstant",
+            "Null",
+            "Record",
+            "Collection",
+            "Path",
+            "If",
+            "Cast",
+            "IsType",
+            "FunctionApplication",
+            "LabeledExpressionReference",
+            "Labeled",
+            "PropertyPath",
+            "NavigationPropertyPath",
+            "DateConstant",
+            "TimeOfDayConstant",
+            "EnumMember",
+            "AnnotationPath"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmExpressionExpressionKind",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "IEdmEntityContainerElement": {
+      "type": "object",
+      "properties": {
+        "ContainerElementKind": {
+          "enum": [
+            "None",
+            "EntitySet",
+            "ActionImport",
+            "FunctionImport",
+            "Singleton"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmEntityContainerElementContainerElementKind",
+            "modelAsString": false
+          }
+        },
+        "Container": {
+          "$ref": "#/definitions/IEdmEntityContainer",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmNavigationProperty": {
+      "type": "object",
+      "properties": {
+        "Partner": {
+          "$ref": "#/definitions/IEdmNavigationProperty",
+          "readOnly": true
+        },
+        "OnDelete": {
+          "enum": [
+            "None",
+            "Cascade"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmNavigationPropertyOnDelete",
+            "modelAsString": false
+          }
+        },
+        "ContainsTarget": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "ReferentialConstraint": {
+          "$ref": "#/definitions/IEdmReferentialConstraint",
+          "readOnly": true
+        },
+        "PropertyKind": {
+          "enum": [
+            "None",
+            "Structural",
+            "Navigation"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmNavigationPropertyPropertyKind",
+            "modelAsString": false
+          }
+        },
+        "Type": {
+          "$ref": "#/definitions/IEdmTypeReference",
+          "readOnly": true
+        },
+        "DeclaringType": {
+          "$ref": "#/definitions/IEdmStructuredType",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmReferentialConstraint": {
+      "type": "object",
+      "properties": {
+        "PropertyPairs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EdmReferentialConstraintPropertyPair"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmStructuredType": {
+      "type": "object",
+      "properties": {
+        "IsAbstract": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "IsOpen": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "BaseType": {
+          "$ref": "#/definitions/IEdmStructuredType",
+          "readOnly": true
+        },
+        "DeclaredProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IEdmProperty"
+          },
+          "readOnly": true
+        },
+        "TypeKind": {
+          "enum": [
+            "None",
+            "Primitive",
+            "Entity",
+            "Complex",
+            "Collection",
+            "EntityReference",
+            "Enum",
+            "TypeDefinition",
+            "Untyped",
+            "Path"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmStructuredTypeTypeKind",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "EdmReferentialConstraintPropertyPair": {
+      "type": "object",
+      "properties": {
+        "DependentProperty": {
+          "$ref": "#/definitions/IEdmStructuralProperty",
+          "readOnly": true
+        },
+        "PrincipalProperty": {
+          "$ref": "#/definitions/IEdmStructuralProperty",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmProperty": {
+      "type": "object",
+      "properties": {
+        "PropertyKind": {
+          "enum": [
+            "None",
+            "Structural",
+            "Navigation"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmPropertyPropertyKind",
+            "modelAsString": false
+          }
+        },
+        "Type": {
+          "$ref": "#/definitions/IEdmTypeReference",
+          "readOnly": true
+        },
+        "DeclaringType": {
+          "$ref": "#/definitions/IEdmStructuredType",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "IEdmStructuralProperty": {
+      "type": "object",
+      "properties": {
+        "DefaultValueString": {
+          "type": "string",
+          "readOnly": true
+        },
+        "PropertyKind": {
+          "enum": [
+            "None",
+            "Structural",
+            "Navigation"
+          ],
+          "type": "string",
+          "readOnly": true,
+          "x-ms-enum": {
+            "name": "IEdmStructuralPropertyPropertyKind",
+            "modelAsString": false
+          }
+        },
+        "Type": {
+          "$ref": "#/definitions/IEdmTypeReference",
+          "readOnly": true
+        },
+        "DeclaringType": {
+          "$ref": "#/definitions/IEdmStructuredType",
+          "readOnly": true
+        },
+        "Name": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ODataResponse[List[AlertDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AlertDto"
+          }
+        }
+      }
+    },
+    "AlertDto": {
+      "description": "Stores notification data used to inform the users about specific application events.",
+      "required": [
+        "Severity"
+      ],
+      "type": "object",
+      "properties": {
+        "NotificationName": {
+          "description": "The name of a specific type of notification, e.g. Robot.StatusChanged.NotResponding.",
+          "type": "string"
+        },
+        "Data": {
+          "description": "Stores data about the context in which the event occurred, in JSON format.",
+          "type": "string"
+        },
+        "Component": {
+          "description": "The component that raised the alert.",
+          "enum": [
+            "Robots",
+            "Transactions",
+            "Schedules",
+            "Jobs",
+            "Process"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AlertDtoComponent",
+            "modelAsString": false
+          }
+        },
+        "Severity": {
+          "description": "The severity level of the alert.",
+          "enum": [
+            "Info",
+            "Success",
+            "Warn",
+            "Error",
+            "Fatal"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AlertDtoSeverity",
+            "modelAsString": false
+          }
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the alert was generated.",
+          "type": "string"
+        },
+        "State": {
+          "description": "Defines if a specified notification has been read or not.\r\n<para />Members: Unread (0) - the specified notification has not been marked as read; Read (1) - the specified notification has been marked as read.",
+          "enum": [
+            "Unread",
+            "Read"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AlertDtoState",
+            "modelAsString": false
+          }
+        },
+        "UserNotificationId": {
+          "format": "uuid",
+          "description": "The database unique identifier for the alert notification sent to the current user.",
+          "type": "string"
+        },
+        "Id": {
+          "format": "uuid",
+          "type": "string"
+        }
+      }
+    },
+    "ODataResponse[Int64]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ProcessAlertDto": {
+      "required": [
+        "Message",
+        "Severity",
+        "RobotName",
+        "ProcessName"
+      ],
+      "type": "object",
+      "properties": {
+        "Message": {
+          "maxLength": 512,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Severity": {
+          "enum": [
+            "Info",
+            "Success",
+            "Warn",
+            "Error",
+            "Fatal"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ProcessAlertDtoSeverity",
+            "modelAsString": false
+          }
+        },
+        "RobotName": {
+          "maxLength": 512,
+          "minLength": 0,
+          "type": "string"
+        },
+        "ProcessName": {
+          "maxLength": 512,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Id": {
+          "format": "uuid",
+          "type": "string"
+        }
+      }
+    },
+    "ODataQueryOptions[AssetDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[AssetDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AssetDto"
+          }
+        }
+      }
+    },
+    "AssetDto": {
+      "description": "Stores specific data so that robots can easily have access to it.",
+      "required": [
+        "Name",
+        "ValueScope"
+      ],
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "A custom name for the asset.",
+          "type": "string"
+        },
+        "CanBeDeleted": {
+          "description": "States if an assets can be deleted. The default value of this property is true.",
+          "type": "boolean"
+        },
+        "ValueScope": {
+          "description": "Defines the scope of the asset.",
+          "enum": [
+            "Global",
+            "PerRobot"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AssetDtoValueScope",
+            "modelAsString": false
+          }
+        },
+        "ValueType": {
+          "description": "Defines the type of value stored by the asset.",
+          "enum": [
+            "DBConnectionString",
+            "HttpConnectionString",
+            "Text",
+            "Bool",
+            "Integer",
+            "Credential",
+            "WindowsCredential",
+            "KeyValueList"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AssetDtoValueType",
+            "modelAsString": false
+          }
+        },
+        "Value": {
+          "description": "The textual representation of the asset value, irrespective of value type.",
+          "type": "string"
+        },
+        "StringValue": {
+          "description": "The value of the asset when the value type is Text. Empty when the value type is not Text.",
+          "type": "string"
+        },
+        "BoolValue": {
+          "description": "The value of the asset when the value type is Bool. False when the value type is not Bool.",
+          "type": "boolean"
+        },
+        "IntValue": {
+          "format": "int32",
+          "description": "The value of the asset when the value type is Integer. 0 when the value type is not Integer.",
+          "type": "integer"
+        },
+        "CredentialUsername": {
+          "description": "The user name when the value type is Credential. Empty when the value type is not Credential.",
+          "type": "string"
+        },
+        "CredentialPassword": {
+          "description": "The password when the value type is Credential. Empty when the value type is not Credential.",
+          "type": "string"
+        },
+        "KeyValueList": {
+          "description": "A collection of key value pairs when the type is KeyValueList. Empty when the value type is not KeyValueList.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CustomKeyValuePair"
+          }
+        },
+        "RobotValues": {
+          "description": "The collection of asset values per robot. Empty if the asset type is Global.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AssetRobotValueDto"
+          }
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "CustomKeyValuePair": {
+      "description": "Stores a custom pair of key and value for assets with type KeyValueList.",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "A piece of text representing the key.",
+          "type": "string"
+        },
+        "Value": {
+          "description": "A piece of text representing the value.",
+          "type": "string"
+        }
+      }
+    },
+    "AssetRobotValueDto": {
+      "description": "Stores the value of an asset associated with a robot as well as the robot association data.",
+      "type": "object",
+      "properties": {
+        "RobotId": {
+          "format": "int64",
+          "description": "The Id of the robot with which the asset is associated.",
+          "type": "integer"
+        },
+        "RobotName": {
+          "description": "The name of the robot with which the asset is associated.",
+          "type": "string"
+        },
+        "KeyTrail": {
+          "description": "Masked value of the robot key.",
+          "type": "string"
+        },
+        "ValueType": {
+          "description": "Defines the type of value stored by the asset.",
+          "enum": [
+            "DBConnectionString",
+            "HttpConnectionString",
+            "Text",
+            "Bool",
+            "Integer",
+            "Credential",
+            "WindowsCredential",
+            "KeyValueList"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AssetRobotValueDtoValueType",
+            "modelAsString": false
+          }
+        },
+        "StringValue": {
+          "description": "The value of the asset when the value type is Text. Empty when the value type is not Text.",
+          "type": "string"
+        },
+        "BoolValue": {
+          "description": "The value of the asset when the value type is Bool. False when the value type is not Bool.",
+          "type": "boolean"
+        },
+        "IntValue": {
+          "format": "int32",
+          "description": "The value of the asset when the value type is Integer. 0 when the value type is not Integer.",
+          "type": "integer"
+        },
+        "Value": {
+          "description": "The textual representation of the asset value, irrespective of value type.",
+          "type": "string"
+        },
+        "CredentialUsername": {
+          "description": "The user name when the value type is Credential. Empty when the value type is not Credential.",
+          "type": "string"
+        },
+        "CredentialPassword": {
+          "description": "The password when the value type is Credential. Empty when the value type is not Credential.",
+          "type": "string"
+        },
+        "KeyValueList": {
+          "description": "A collection of key value pairs when the type is KeyValueList. Empty when the value type is not KeyValueList.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CustomKeyValuePair"
+          }
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "RobotAssetDto": {
+      "description": "A robot asset stores the information of a per robot asset for a specific robot, without specifying the robot.",
+      "required": [
+        "Name"
+      ],
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "The asset name.",
+          "type": "string"
+        },
+        "ValueType": {
+          "description": "Defines the type of value stored by the asset.",
+          "enum": [
+            "DBConnectionString",
+            "HttpConnectionString",
+            "Text",
+            "Bool",
+            "Integer",
+            "Credential",
+            "WindowsCredential",
+            "KeyValueList"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RobotAssetDtoValueType",
+            "modelAsString": false
+          }
+        },
+        "StringValue": {
+          "description": "The value of the asset when the value type is Text. Empty when the value type is not Text.",
+          "type": "string"
+        },
+        "BoolValue": {
+          "description": "The value of the asset when the value type is Bool. False when the value type is not Bool.",
+          "type": "boolean"
+        },
+        "IntValue": {
+          "format": "int32",
+          "description": "The value of the asset when the value type is Integer. 0 when the value type is not Integer.",
+          "type": "integer"
+        },
+        "CredentialUsername": {
+          "description": "The user name when the value type is Credential. Empty when the value type is not Credential.",
+          "type": "string"
+        },
+        "CredentialPassword": {
+          "description": "The password when the value type is Credential. Empty when the value type is not Credential.",
+          "type": "string"
+        }
+      }
+    },
+    "ODataQueryOptions[AuditLogDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[AuditLogDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuditLogDto"
+          }
+        }
+      }
+    },
+    "AuditLogDto": {
+      "description": "Stores audit information about any action performed in Orchestrator.",
+      "type": "object",
+      "properties": {
+        "ServiceName": {
+          "description": "The name of the Orchestrator service that performed a given action in the system.",
+          "type": "string"
+        },
+        "MethodName": {
+          "description": "The name of the service method that performed a given action in the system.",
+          "type": "string"
+        },
+        "Parameters": {
+          "description": "JSON representation of the method parameters and their values for the given action.",
+          "type": "string"
+        },
+        "ExecutionTime": {
+          "format": "date-time",
+          "description": "The date and time when the action was performed.",
+          "type": "string"
+        },
+        "Action": {
+          "description": "The action performed (create, update, delete etc)",
+          "enum": [
+            "Unknown",
+            "Create",
+            "Update",
+            "Delete",
+            "StartJob",
+            "StopJob",
+            "Associate",
+            "Upload",
+            "ChangeStatus",
+            "Import",
+            "ChangePassword",
+            "Register",
+            "Toggle",
+            "ResetPassword",
+            "PasswordResetAttempt",
+            "Download",
+            "Acknowledge"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AuditLogDtoAction",
+            "modelAsString": false
+          }
+        },
+        "Component": {
+          "description": "The component for which the action was performed",
+          "enum": [
+            "Unknown",
+            "Assets",
+            "Environments",
+            "Processes",
+            "Queues",
+            "Robots",
+            "Roles",
+            "Schedules",
+            "Users",
+            "Comments",
+            "Units",
+            "Jobs",
+            "Settings",
+            "Packages",
+            "License",
+            "Tenant",
+            "Machines",
+            "Libraries",
+            "Webhooks",
+            "ExecutionMedia",
+            "Monitoring"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AuditLogDtoComponent",
+            "modelAsString": false
+          }
+        },
+        "DisplayName": {
+          "description": "The display name of the resource acted on, usually Name",
+          "type": "string"
+        },
+        "EntityId": {
+          "format": "int64",
+          "description": "The Id of the resource acted on",
+          "type": "integer"
+        },
+        "OperationText": {
+          "description": "User friendly description of the change, e.g. \"User X created robot Y\"",
+          "type": "string"
+        },
+        "UserName": {
+          "description": "UserName that sent the request",
+          "type": "string"
+        },
+        "UserType": {
+          "description": "The type of user that sent the request",
+          "enum": [
+            "User",
+            "Robot"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AuditLogDtoUserType",
+            "modelAsString": false
+          }
+        },
+        "Entities": {
+          "description": "Audit entity details collection",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuditLogEntityDto"
+          }
+        },
+        "UserId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "UserIsDeleted": {
+          "description": "Marks whether the users that did the action was deleted in the meantime",
+          "type": "boolean"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "AuditLogEntityDto": {
+      "description": "Stores audit information about any action performed in Orchestrator.",
+      "type": "object",
+      "properties": {
+        "AuditLogId": {
+          "format": "int64",
+          "description": "Business audit entry that triggered the changes",
+          "type": "integer"
+        },
+        "CustomData": {
+          "description": "Data about the old/new/included values",
+          "type": "string"
+        },
+        "EntityId": {
+          "format": "int64",
+          "description": "The Id of the referred entity",
+          "type": "integer"
+        },
+        "EntityName": {
+          "description": "The name of the entity the auditLog refers to",
+          "type": "string"
+        },
+        "Action": {
+          "description": "The action (created, updated, deleted etc)",
+          "enum": [
+            "Unknown",
+            "Create",
+            "Update",
+            "Delete",
+            "StartJob",
+            "StopJob",
+            "Associate",
+            "Upload",
+            "ChangeStatus",
+            "Import",
+            "ChangePassword",
+            "Register",
+            "Toggle",
+            "ResetPassword",
+            "PasswordResetAttempt",
+            "Download",
+            "Acknowledge"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "AuditLogEntityDtoAction",
+            "modelAsString": false
+          }
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataResponse[List[AuditLogEntityDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AuditLogEntityDto"
+          }
+        }
+      }
+    },
+    "ODataQueryOptions[EnvironmentDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[EnvironmentDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EnvironmentDto"
+          }
+        }
+      }
+    },
+    "EnvironmentDto": {
+      "description": "A grouping of Robots.",
+      "required": [
+        "Name"
+      ],
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "A custom name for the environment.",
+          "maxLength": 100,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Description": {
+          "description": "Used to add additional information about an environment in order to better identify it.",
+          "maxLength": 500,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Robots": {
+          "description": "The collection of robots associated with the current environment.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SimpleRobotDto"
+          }
+        },
+        "Type": {
+          "description": "DEPRECATED. The environment type specifies how it should be used.\r\nThis property is deprecated and should no longer be used.",
+          "enum": [
+            "Dev",
+            "Test",
+            "Prod"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "EnvironmentDtoType",
+            "modelAsString": false
+          },
+          "x-deprecated": true
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "SimpleRobotDto": {
+      "description": "Entity derived from RobotDto. Is shares all the properties of the base entity except the navigation properties.",
+      "required": [
+        "Name",
+        "Username",
+        "Type",
+        "HostingType"
+      ],
+      "type": "object",
+      "properties": {
+        "LicenseKey": {
+          "description": "The key is automatically generated from the server for the Robot machine.\r\n<para />For the robot to work, the same key must exist on both the robot and Orchestrator.\r\n<para />All robots on a machine must have the same license key in order to register correctly.",
+          "maxLength": 255,
+          "minLength": 0,
+          "type": "string"
+        },
+        "MachineName": {
+          "description": "The name of the machine a Robot is hosted on.",
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "MachineId": {
+          "format": "int64",
+          "description": "The Id of the machine a Robot is hosted on",
+          "type": "integer"
+        },
+        "Name": {
+          "description": "A custom name for the robot.",
+          "maxLength": 19,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Username": {
+          "description": "The machine username. If the user is under a domain, you are required to also specify it in a DOMAIN\\username format.\r\n<para />Note: You must use short domain names, such as desktop\\administrator and NOT desktop.local/administrator.",
+          "maxLength": 100,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Description": {
+          "description": "Used to add additional information about a robot in order to better identify it.",
+          "maxLength": 500,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Version": {
+          "description": "The Robot's Version.",
+          "type": "string"
+        },
+        "Type": {
+          "description": "The Robot type.",
+          "enum": [
+            "NonProduction",
+            "Attended",
+            "Unattended",
+            "Development"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SimpleRobotDtoType",
+            "modelAsString": false
+          }
+        },
+        "HostingType": {
+          "description": "The Robot hosting type (Standard / Floating).",
+          "enum": [
+            "Standard",
+            "Floating"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SimpleRobotDtoHostingType",
+            "modelAsString": false
+          }
+        },
+        "Password": {
+          "description": "The Windows password associated with the machine username.",
+          "maxLength": 100,
+          "minLength": 0,
+          "type": "string"
+        },
+        "CredentialType": {
+          "description": "The robot credentials type (Default/ SmartCard)",
+          "enum": [
+            "Default",
+            "SmartCard"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SimpleRobotDtoCredentialType",
+            "modelAsString": false
+          }
+        },
+        "Environments": {
+          "description": "The collection of environments the robot is part of.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EnvironmentDto"
+          }
+        },
+        "RobotEnvironments": {
+          "description": "The comma separated textual representation of environment names the robot is part of.",
+          "type": "string"
+        },
+        "ExecutionSettings": {
+          "description": "A collection of key value pairs containing execution settings for this robot.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ExecutionSettingsValues": {
+      "type": "object",
+      "properties": {}
+    },
+    "ODataQueryOptions[RobotDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[RobotDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RobotDto"
+          }
+        }
+      }
+    },
+    "RobotDto": {
+      "description": "A Robot is an execution host that runs processes built in UiPath Studio.",
+      "required": [
+        "Name",
+        "Username",
+        "Type",
+        "HostingType"
+      ],
+      "type": "object",
+      "properties": {
+        "LicenseKey": {
+          "description": "The key is automatically generated from the server for the Robot machine.\r\n<para />For the robot to work, the same key must exist on both the robot and Orchestrator.\r\n<para />All robots on a machine must have the same license key in order to register correctly.",
+          "maxLength": 255,
+          "minLength": 0,
+          "type": "string"
+        },
+        "MachineName": {
+          "description": "The name of the machine a Robot is hosted on.",
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "MachineId": {
+          "format": "int64",
+          "description": "The Id of the machine a Robot is hosted on",
+          "type": "integer"
+        },
+        "Name": {
+          "description": "A custom name for the robot.",
+          "maxLength": 19,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Username": {
+          "description": "The machine username. If the user is under a domain, you are required to also specify it in a DOMAIN\\username format.\r\n<para />Note: You must use short domain names, such as desktop\\administrator and NOT desktop.local/administrator.",
+          "maxLength": 100,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Description": {
+          "description": "Used to add additional information about a robot in order to better identify it.",
+          "maxLength": 500,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Version": {
+          "description": "The Robot's Version.",
+          "type": "string"
+        },
+        "Type": {
+          "description": "The Robot type.",
+          "enum": [
+            "NonProduction",
+            "Attended",
+            "Unattended",
+            "Development"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RobotDtoType",
+            "modelAsString": false
+          }
+        },
+        "HostingType": {
+          "description": "The Robot hosting type (Standard / Floating).",
+          "enum": [
+            "Standard",
+            "Floating"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RobotDtoHostingType",
+            "modelAsString": false
+          }
+        },
+        "Password": {
+          "description": "The Windows password associated with the machine username.",
+          "maxLength": 100,
+          "minLength": 0,
+          "type": "string"
+        },
+        "CredentialType": {
+          "description": "The robot credentials type (Default/ SmartCard)",
+          "enum": [
+            "Default",
+            "SmartCard"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RobotDtoCredentialType",
+            "modelAsString": false
+          }
+        },
+        "Environments": {
+          "description": "The collection of environments the robot is part of.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EnvironmentDto"
+          }
+        },
+        "RobotEnvironments": {
+          "description": "The comma separated textual representation of environment names the robot is part of.",
+          "type": "string"
+        },
+        "ExecutionSettings": {
+          "description": "A collection of key value pairs containing execution settings for this robot.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataResponse[List[Int64]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "format": "int64",
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "ODataQueryOptions[ExecutionMediaDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[ExecutionMediaDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExecutionMediaDto"
+          }
+        }
+      }
+    },
+    "ExecutionMediaDto": {
+      "type": "object",
+      "properties": {
+        "StorageLocation": {
+          "maxLength": 255,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Name": {
+          "maxLength": 255,
+          "minLength": 0,
+          "type": "string"
+        },
+        "JobId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "ReleaseName": {
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[HostLicenseDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[HostLicenseDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HostLicenseDto"
+          }
+        }
+      }
+    },
+    "HostLicenseDto": {
+      "description": "Stores information about the host license used to activate one or more tenants.",
+      "type": "object",
+      "properties": {
+        "TenantsCount": {
+          "format": "int32",
+          "description": "The number of tenants licensed from this license file",
+          "type": "integer"
+        },
+        "Id": {
+          "format": "int64",
+          "description": "License Id",
+          "type": "integer"
+        },
+        "ExpireDate": {
+          "format": "int64",
+          "description": "License expiration date in Epoch format",
+          "type": "integer"
+        },
+        "Allowed": {
+          "$ref": "#/definitions/LicenseFields",
+          "description": "Contains the number of allowed licenses for each type"
+        },
+        "Used": {
+          "$ref": "#/definitions/LicenseFields",
+          "description": "Contains the number of used licenses for each type"
+        },
+        "AttendedConcurrent": {
+          "description": "States whether the license is Attended Concurrent",
+          "type": "boolean"
+        },
+        "DevelopmentConcurrent": {
+          "description": "States whether the license is Development Concurrent",
+          "type": "boolean"
+        },
+        "IsRegistered": {
+          "description": "True if the current tenant is registered with a license. False otherwise.",
+          "type": "boolean"
+        },
+        "IsExpired": {
+          "description": "States whether the license is still valid or not.",
+          "type": "boolean"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date when the license was uploaded.",
+          "type": "string"
+        },
+        "Code": {
+          "description": "The license code.",
+          "type": "string"
+        }
+      }
+    },
+    "LicenseFields": {
+      "type": "object",
+      "properties": {
+        "Unattended": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "Attended": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "NonProduction": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "Development": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "LicenseDto": {
+      "description": "Stores information about the license used to activate a tenant.",
+      "type": "object",
+      "properties": {
+        "HostLicenseId": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "Id": {
+          "format": "int64",
+          "description": "License Id",
+          "type": "integer"
+        },
+        "ExpireDate": {
+          "format": "int64",
+          "description": "License expiration date in Epoch format",
+          "type": "integer"
+        },
+        "Allowed": {
+          "$ref": "#/definitions/LicenseFields",
+          "description": "Contains the number of allowed licenses for each type"
+        },
+        "Used": {
+          "$ref": "#/definitions/LicenseFields",
+          "description": "Contains the number of used licenses for each type"
+        },
+        "AttendedConcurrent": {
+          "description": "States whether the license is Attended Concurrent",
+          "type": "boolean"
+        },
+        "DevelopmentConcurrent": {
+          "description": "States whether the license is Development Concurrent",
+          "type": "boolean"
+        },
+        "IsRegistered": {
+          "description": "True if the current tenant is registered with a license. False otherwise.",
+          "type": "boolean"
+        },
+        "IsExpired": {
+          "description": "States whether the license is still valid or not.",
+          "type": "boolean"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date when the license was uploaded.",
+          "type": "string"
+        },
+        "Code": {
+          "description": "The license code.",
+          "type": "string"
+        }
+      }
+    },
+    "HostLicensePerTenantDto": {
+      "type": "object",
+      "properties": {
+        "TenantId": {
+          "format": "int32",
+          "description": "The tenant's Id",
+          "type": "integer"
+        },
+        "HostLicenseId": {
+          "format": "int64",
+          "description": "The host license's Id",
+          "type": "integer"
+        },
+        "Attended": {
+          "format": "int64",
+          "description": "Number of allowed attended robots",
+          "type": "integer"
+        },
+        "Unattended": {
+          "format": "int64",
+          "description": "Number of allowed unattended robots",
+          "type": "integer"
+        },
+        "NonProduction": {
+          "format": "int64",
+          "description": "Number of allowed non-production robots",
+          "type": "integer"
+        },
+        "Development": {
+          "format": "int64",
+          "description": "Number of allowed development robots",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[JobDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[JobDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JobDto"
+          }
+        }
+      }
+    },
+    "JobDto": {
+      "description": "Represents a scheduled or manual execution of a process on a robot.",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "format": "uuid",
+          "description": "The unique job identifier.",
+          "type": "string"
+        },
+        "StartTime": {
+          "format": "date-time",
+          "description": "The date and time when the job execution started or null if the job hasn't started yet.",
+          "type": "string"
+        },
+        "EndTime": {
+          "format": "date-time",
+          "description": "The date and time when the job execution ended or null if the job hasn't ended yet.",
+          "type": "string"
+        },
+        "State": {
+          "description": "The state in which the job is.",
+          "enum": [
+            "Pending",
+            "Running",
+            "Stopping",
+            "Terminating",
+            "Faulted",
+            "Successful",
+            "Stopped"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "JobDtoState",
+            "modelAsString": false
+          }
+        },
+        "Robot": {
+          "$ref": "#/definitions/SimpleRobotDto",
+          "description": "The robot associated with the current job."
+        },
+        "Release": {
+          "$ref": "#/definitions/SimpleReleaseDto",
+          "description": "The release associated with the current job."
+        },
+        "Source": {
+          "description": "The Source name of the job.",
+          "type": "string"
+        },
+        "SourceType": {
+          "description": "The Source type of the job.",
+          "enum": [
+            "Manual",
+            "Schedule",
+            "Agent"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "JobDtoSourceType",
+            "modelAsString": false
+          }
+        },
+        "BatchExecutionKey": {
+          "format": "uuid",
+          "description": "The unique identifier grouping multiple jobs. It is usually generated when the job is created by a schedule.",
+          "type": "string"
+        },
+        "Info": {
+          "description": "Additional information about the current job.",
+          "type": "string"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the job was created.",
+          "type": "string"
+        },
+        "StartingScheduleId": {
+          "format": "int64",
+          "description": "The Id of the schedule that started the job, or null if the job was started by the user.",
+          "type": "integer"
+        },
+        "ReleaseName": {
+          "description": "The name of the release associated with the current name.",
+          "type": "string"
+        },
+        "Type": {
+          "description": "The type of the job, Attended if started via the robot, Unattended otherwise",
+          "enum": [
+            "Unattended",
+            "Attended"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "JobDtoType",
+            "modelAsString": false
+          }
+        },
+        "InputArguments": {
+          "description": "Input parameters in JSON format to be passed to job execution",
+          "type": "string"
+        },
+        "OutputArguments": {
+          "description": "Output parameters in JSON format resulted from job execution",
+          "type": "string"
+        },
+        "HostMachineName": {
+          "description": "The name of the machine where the Robot run the job.",
+          "type": "string"
+        },
+        "HasMediaRecorded": {
+          "description": "True if any execution media has been recorded for this job, false otherwise.",
+          "type": "boolean"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "SimpleReleaseDto": {
+      "description": "Entity derived from ReleaseDto. It shares all the properties of the base entity except the navigation properties.",
+      "required": [
+        "ProcessKey",
+        "ProcessVersion",
+        "Name",
+        "EnvironmentId"
+      ],
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "A unique identifier associated to each release.",
+          "type": "string"
+        },
+        "ProcessKey": {
+          "description": "The unique identifier of the process associated with the release.",
+          "type": "string"
+        },
+        "ProcessVersion": {
+          "description": "The version of the process associated with the release.",
+          "type": "string"
+        },
+        "IsLatestVersion": {
+          "description": "States whether the version of process associated with the release is latest or not.",
+          "type": "boolean"
+        },
+        "IsProcessDeleted": {
+          "description": "States whether the process associated with the release is deleted or not.",
+          "type": "boolean"
+        },
+        "Description": {
+          "description": "Used to add additional information about a release in order to better identify it.",
+          "type": "string"
+        },
+        "Name": {
+          "description": "A custom name of the release. The default name format is ProcessName_EnvironmentName.",
+          "type": "string"
+        },
+        "EnvironmentId": {
+          "format": "int64",
+          "description": "The Id of the environment associated with the release.",
+          "type": "integer"
+        },
+        "EnvironmentName": {
+          "description": "The name of the environment associated with the release.",
+          "type": "string"
+        },
+        "Environment": {
+          "$ref": "#/definitions/EnvironmentDto",
+          "description": "The environment associated with the release."
+        },
+        "InputArguments": {
+          "description": "Input parameters in JSON format to be passed as default values to job execution.",
+          "type": "string"
+        },
+        "CurrentVersion": {
+          "$ref": "#/definitions/ReleaseVersionDto",
+          "description": "The release version associated with the current release."
+        },
+        "ReleaseVersions": {
+          "description": "The collection of release versions that current release had over time.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReleaseVersionDto"
+          }
+        },
+        "Arguments": {
+          "$ref": "#/definitions/ArgumentMetadata",
+          "description": "Input/Output arguments consumed/produced by the release"
+        },
+        "ProcessSettings": {
+          "$ref": "#/definitions/ProcessSettingsDto"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ReleaseVersionDto": {
+      "description": "Stores data about a version of the various versions of the process associated with a certain release.\r\n<para />If a certain version is associated on and off with a release a new ReleaseVersion object is created for each association.",
+      "required": [
+        "ReleaseId",
+        "VersionNumber"
+      ],
+      "type": "object",
+      "properties": {
+        "ReleaseId": {
+          "format": "int64",
+          "description": "The Id of the parent release.",
+          "type": "integer"
+        },
+        "VersionNumber": {
+          "description": "The version of process associated with the release.",
+          "type": "string"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the version was associated with the release.",
+          "type": "string"
+        },
+        "ReleaseName": {
+          "description": "The name of the process associated with the release.",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ArgumentMetadata": {
+      "type": "object",
+      "properties": {
+        "Input": {
+          "type": "string"
+        },
+        "Output": {
+          "type": "string"
+        }
+      }
+    },
+    "ProcessSettingsDto": {
+      "type": "object",
+      "properties": {
+        "ErrorRecordingEnabled": {
+          "type": "boolean"
+        },
+        "Duration": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "Frequency": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "Quality": {
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "StartProcessDto": {
+      "description": "The Start Process transfers information from client to the server during JobsController.StartJobs custom action.",
+      "required": [
+        "ReleaseKey"
+      ],
+      "type": "object",
+      "properties": {
+        "ReleaseKey": {
+          "description": "The unique key of the release associated with the process.",
+          "type": "string"
+        },
+        "Strategy": {
+          "description": "States which robots from the environment are being run by the process.",
+          "enum": [
+            "All",
+            "Specific",
+            "RobotCount",
+            "JobsCount"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "StartProcessDtoStrategy",
+            "modelAsString": false
+          }
+        },
+        "RobotIds": {
+          "description": "The collection of ids of specific robots selected to be run by the current process. This collection must be empty only if the start strategy is not Specific.",
+          "type": "array",
+          "items": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "NoOfRobots": {
+          "format": "int32",
+          "description": "DEPRECATED. Number of pending jobs to be created in the environment, for the current process. This number must be greater than 0 only if the start strategy is RobotCount.",
+          "type": "integer",
+          "x-deprecated": true
+        },
+        "JobsCount": {
+          "format": "int32",
+          "description": "Number of pending jobs to be created in the environment, for the current process. This number must be greater than 0 only if the start strategy is JobsCount.",
+          "type": "integer"
+        },
+        "Source": {
+          "description": "The Source of the job starting the current process.",
+          "enum": [
+            "Manual",
+            "Schedule"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "StartProcessDtoSource",
+            "modelAsString": false
+          }
+        },
+        "InputArguments": {
+          "description": "Input parameters in JSON format to be passed to job execution.",
+          "type": "string"
+        }
+      }
+    },
+    "ODataQueryOptions[LibraryDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[LibraryDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LibraryDto"
+          }
+        }
+      }
+    },
+    "LibraryDto": {
+      "type": "object",
+      "properties": {
+        "Title": {
+          "description": "The custom name of the package.",
+          "type": "string"
+        },
+        "Version": {
+          "description": "The current version of the given package.",
+          "type": "string"
+        },
+        "Key": {
+          "description": "The unique identifier for the package.",
+          "type": "string"
+        },
+        "Description": {
+          "description": "Used to add additional information about a package in order to better identify it.",
+          "type": "string"
+        },
+        "Published": {
+          "format": "date-time",
+          "description": "The date and time when the package was published or uploaded.",
+          "type": "string"
+        },
+        "IsLatestVersion": {
+          "description": "Specifies whether the current version is the latest of the given package.",
+          "type": "boolean"
+        },
+        "OldVersion": {
+          "description": "Specifies the last version before the current one.",
+          "type": "string"
+        },
+        "ReleaseNotes": {
+          "description": "Package release notes.",
+          "type": "string"
+        },
+        "Authors": {
+          "description": "Package authors.",
+          "type": "string"
+        },
+        "Id": {
+          "type": "string"
+        }
+      }
+    },
+    "ODataQueryOptions[LicenseNamedUserDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[LicenseNamedUserDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LicenseNamedUserDto"
+          }
+        }
+      }
+    },
+    "LicenseNamedUserDto": {
+      "description": "Stores information about a named-user license (attended/development).",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "The license key.",
+          "type": "string"
+        },
+        "UserName": {
+          "description": "The Robot's UserName.",
+          "type": "string"
+        },
+        "LastLoginDate": {
+          "format": "date-time",
+          "description": "The last date when the Robot acquired a license.",
+          "type": "string"
+        },
+        "MachinesCount": {
+          "format": "int32",
+          "description": "Total number of machines where a robot with UserName is defined.",
+          "type": "integer"
+        },
+        "IsLicensed": {
+          "description": "If the license is in use.",
+          "type": "boolean"
+        },
+        "ActiveRobotId": {
+          "format": "int64",
+          "description": "The Id of the Robot that uses the license.",
+          "type": "integer"
+        },
+        "MachineNames": {
+          "description": "The Machine names of the defined Robot.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ActiveMachineNames": {
+          "description": "The Machine names of the connected and licensed Robot.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ODataQueryOptions[LicenseRuntimeDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[LicenseRuntimeDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LicenseRuntimeDto"
+          }
+        }
+      }
+    },
+    "LicenseRuntimeDto": {
+      "description": "Stores information about a runtime license (unattended/non-production).",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "The license key.",
+          "type": "string"
+        },
+        "MachineId": {
+          "format": "int64",
+          "description": "The Machine's Id.",
+          "type": "integer"
+        },
+        "MachineName": {
+          "description": "The Machine's Name.",
+          "type": "string"
+        },
+        "Runtimes": {
+          "format": "int32",
+          "description": "Maximum number of runtimes.",
+          "type": "integer"
+        },
+        "RobotsCount": {
+          "format": "int32",
+          "description": "Total number of Robots.",
+          "type": "integer"
+        },
+        "ExecutingCount": {
+          "format": "int32",
+          "description": "How many Robots acquired a license.",
+          "type": "integer"
+        },
+        "IsOnline": {
+          "description": "If the machine is online.",
+          "type": "boolean"
+        },
+        "IsLicensed": {
+          "description": "If the machine is licensed.",
+          "type": "boolean"
+        },
+        "Enabled": {
+          "description": "If the machine is allowed to consume licenses.",
+          "type": "boolean"
+        }
+      }
+    },
+    "ODataQueryOptions[MachineDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[MachineDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MachineDto"
+          }
+        }
+      }
+    },
+    "MachineDto": {
+      "description": "The Machine that hosts the Robot",
+      "required": [
+        "Name"
+      ],
+      "type": "object",
+      "properties": {
+        "LicenseKey": {
+          "description": "The key is automatically generated from the server for the Robot machine.\r\n<para />For the robot to work, the same key must exist on both the robot and Orchestrator.\r\n<para />All robots on a machine must have the same license key in order to register correctly.",
+          "maxLength": 255,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Name": {
+          "description": "The name of the Machine a Robot is hosted on.",
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Type": {
+          "description": "The type of the Machine (Standard / Template).",
+          "enum": [
+            "Standard",
+            "Template"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "MachineDtoType",
+            "modelAsString": false
+          }
+        },
+        "NonProductionSlots": {
+          "format": "int32",
+          "description": "Number of NonProduction slots to be reserved at runtime",
+          "type": "integer"
+        },
+        "UnattendedSlots": {
+          "format": "int32",
+          "description": "Number of Unattended slots to be reserved at runtime",
+          "type": "integer"
+        },
+        "RobotVersions": {
+          "description": "The versions of the Robots hosted on the Machine.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MachinesRobotVersionDto"
+          }
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "MachinesRobotVersionDto": {
+      "type": "object",
+      "properties": {
+        "Count": {
+          "format": "int64",
+          "description": "The number of Robots on the Machine with the specified version.",
+          "type": "integer"
+        },
+        "Version": {
+          "description": "The Version of the Robot hosted on the Machine.",
+          "type": "string"
+        },
+        "MachineId": {
+          "format": "int64",
+          "description": "The Id of the Machine.",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[MessageTemplateDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[MessageTemplateDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MessageTemplateDto"
+          }
+        }
+      }
+    },
+    "MessageTemplateDto": {
+      "description": "Used to store various predefined application message templates like custom login layout.",
+      "required": [
+        "Name"
+      ],
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "The name of a specific template (e.g. Templates.LoginLayout).",
+          "type": "string"
+        },
+        "Value": {
+          "description": "The value assigned to a specific template.",
+          "type": "string"
+        },
+        "Id": {
+          "type": "string"
+        }
+      }
+    },
+    "ODataQueryOptions[PermissionDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[PermissionDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionDto"
+          }
+        }
+      }
+    },
+    "PermissionDto": {
+      "description": "Stores information about an application permission and role association.",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "The name of the application permission.",
+          "type": "string"
+        },
+        "IsGranted": {
+          "description": "States if a user associated with the role will be allowed or denied to perform the actions governed by the permission.",
+          "type": "boolean"
+        },
+        "RoleId": {
+          "format": "int32",
+          "description": "The Id of the role associated with the permission.",
+          "type": "integer"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[ProcessDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[ProcessDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProcessDto"
+          }
+        }
+      }
+    },
+    "ProcessDto": {
+      "description": "A process is a project defined in UiPath Studio and published in Orchestrator from UiPath Studio or manually.",
+      "type": "object",
+      "properties": {
+        "IsActive": {
+          "description": "Specifies if the process is still active.",
+          "type": "boolean"
+        },
+        "Arguments": {
+          "$ref": "#/definitions/ArgumentMetadata",
+          "description": "Input/Output arguments supported by the process"
+        },
+        "Title": {
+          "description": "The custom name of the package.",
+          "type": "string"
+        },
+        "Version": {
+          "description": "The current version of the given package.",
+          "type": "string"
+        },
+        "Key": {
+          "description": "The unique identifier for the package.",
+          "type": "string"
+        },
+        "Description": {
+          "description": "Used to add additional information about a package in order to better identify it.",
+          "type": "string"
+        },
+        "Published": {
+          "format": "date-time",
+          "description": "The date and time when the package was published or uploaded.",
+          "type": "string"
+        },
+        "IsLatestVersion": {
+          "description": "Specifies whether the current version is the latest of the given package.",
+          "type": "boolean"
+        },
+        "OldVersion": {
+          "description": "Specifies the last version before the current one.",
+          "type": "string"
+        },
+        "ReleaseNotes": {
+          "description": "Package release notes.",
+          "type": "string"
+        },
+        "Authors": {
+          "description": "Package authors.",
+          "type": "string"
+        },
+        "Id": {
+          "type": "string"
+        }
+      }
+    },
+    "ODataQueryOptions[ProcessScheduleDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[ProcessScheduleDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProcessScheduleDto"
+          }
+        }
+      }
+    },
+    "ProcessScheduleDto": {
+      "description": "Defines the schedule of a process that can be executed at regular intervals, on selected Robots, all of them or a specified number of Robots.",
+      "required": [
+        "Name"
+      ],
+      "type": "object",
+      "properties": {
+        "Enabled": {
+          "description": "Specifies if the schedule is active or not.",
+          "type": "boolean"
+        },
+        "Name": {
+          "description": "The name of the schedule.",
+          "type": "string"
+        },
+        "ReleaseId": {
+          "format": "int64",
+          "description": "The Id of the process associated with the schedule.",
+          "type": "integer"
+        },
+        "ReleaseKey": {
+          "description": "The unique key of the process associated with the schedule.",
+          "type": "string"
+        },
+        "ReleaseName": {
+          "description": "The name of the process associated with the schedule.",
+          "type": "string"
+        },
+        "PackageName": {
+          "description": "The name of the package to be triggered with the schedule.",
+          "type": "string"
+        },
+        "EnvironmentName": {
+          "description": "The name of the environment associated with the schedule.",
+          "type": "string"
+        },
+        "EnvironmentId": {
+          "description": "The Id of the environment associated with the schedule.",
+          "type": "string"
+        },
+        "StartProcessCron": {
+          "description": "The start cron expression of the schedule.",
+          "type": "string"
+        },
+        "StartProcessCronDetails": {
+          "description": "Various details that can be associated to the time period expression of the schedule.",
+          "type": "string"
+        },
+        "StartProcessCronSummary": {
+          "description": "Human readable form of cron expression of the schedule.",
+          "type": "string"
+        },
+        "StartProcessNextOccurrence": {
+          "format": "date-time",
+          "description": "The date and time when the associated process will be run next.",
+          "type": "string"
+        },
+        "StartStrategy": {
+          "format": "int32",
+          "description": "States which robots from the environment are being run by the schedule.",
+          "type": "integer"
+        },
+        "ExecutorRobots": {
+          "description": "The collection of specific robots selected to be targeted by the current schedule. This collection must be empty if the start strategy is not 0 (specific robots).",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RobotExecutorDto"
+          }
+        },
+        "StopProcessExpression": {
+          "description": "The cron expression after which a running process will be stopped.",
+          "type": "string"
+        },
+        "StopStrategy": {
+          "description": "The way a running process is stopped.",
+          "enum": [
+            "SoftStop",
+            "Kill"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ProcessScheduleDtoStopStrategy",
+            "modelAsString": false
+          }
+        },
+        "ExternalJobKey": {
+          "description": "The unique identifier of the external job associated with the jobs generated by this schedule. A key is generated for each group of jobs triggered by this schedule.",
+          "type": "string"
+        },
+        "TimeZoneId": {
+          "description": "The timezone under which the schedule will run.",
+          "type": "string"
+        },
+        "TimeZoneIana": {
+          "description": "The timezone under which the schedule will run in Iana Standard.",
+          "type": "string"
+        },
+        "UseCalendar": {
+          "description": "Specify whether the schedule uses the bank holiday calendar",
+          "type": "boolean"
+        },
+        "StopProcessDate": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "InputArguments": {
+          "description": "Input parameters that will be passed to each job created by this schedule.",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "RobotExecutorDto": {
+      "description": "Stores information about a robot on which a process will be executed.",
+      "type": "object",
+      "properties": {
+        "MachineName": {
+          "description": "The name of the machine on which the robot runs the job.",
+          "type": "string"
+        },
+        "Name": {
+          "description": "The name of the robot that runs the job.",
+          "type": "string"
+        },
+        "Description": {
+          "description": "The description of the robot that runs the job.",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataResponse[Boolean]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ODataQueryOptions[QueueDefinitionDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[QueueDefinitionDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueueDefinitionDto"
+          }
+        }
+      }
+    },
+    "QueueDefinitionDto": {
+      "description": "The definition of a work queue. A work queue contains work items that are processed by robots.",
+      "required": [
+        "Name"
+      ],
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "A custom name for the queue.",
+          "type": "string"
+        },
+        "Description": {
+          "description": "Used to add additional information about a queue in order to better identify it.",
+          "type": "string"
+        },
+        "MaxNumberOfRetries": {
+          "format": "int32",
+          "description": "An integer value representing the number of times an item of this queue can be retried if its processing fails with application exception and auto retry is on.",
+          "type": "integer"
+        },
+        "AcceptAutomaticallyRetry": {
+          "description": "States whether a robot should retry to process an item if, after processing, it failed with application exception.",
+          "type": "boolean"
+        },
+        "EnforceUniqueReference": {
+          "description": "States whether Item Reference field should be unique per Queue. Deleted and retried items are not checked against this rule.",
+          "type": "boolean"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the queue was created.",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[QueueItemReportableDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataQueryOptions[QueueItemCommentDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[QueueItemCommentDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueueItemCommentDto"
+          }
+        }
+      }
+    },
+    "QueueItemCommentDto": {
+      "description": "Stores information about a comment posted by an Orchestrator user on a queue item.",
+      "required": [
+        "Text"
+      ],
+      "type": "object",
+      "properties": {
+        "Text": {
+          "description": "The comment body.",
+          "maxLength": 512,
+          "minLength": 0,
+          "type": "string"
+        },
+        "QueueItemId": {
+          "format": "int64",
+          "description": "The Id of a Queue Item that the current item is connected to.",
+          "type": "integer"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the comment was created.",
+          "type": "string"
+        },
+        "UserId": {
+          "format": "int64",
+          "description": "The id of the User that authored the comment.",
+          "type": "integer"
+        },
+        "UserName": {
+          "description": "The name of the User that authored the comment.",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[QueueItemEventDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[QueueItemEventDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueueItemEventDto"
+          }
+        }
+      }
+    },
+    "QueueItemEventDto": {
+      "description": "Stores information about an event on a queue item.",
+      "type": "object",
+      "properties": {
+        "QueueItemId": {
+          "format": "int64",
+          "description": "The Id of a Queue Item that the current item is connected to.",
+          "type": "integer"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "description": "The Date and Time when the event occured.",
+          "type": "string"
+        },
+        "Action": {
+          "description": "The Action that caused the event.",
+          "enum": [
+            "Create",
+            "Edit",
+            "Delete",
+            "Status",
+            "Retry"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "QueueItemEventDtoAction",
+            "modelAsString": false
+          }
+        },
+        "Data": {
+          "description": "The Data associated to the event.",
+          "type": "string"
+        },
+        "UserId": {
+          "format": "int64",
+          "description": "The Id of the User that caused the event.",
+          "type": "integer"
+        },
+        "UserName": {
+          "description": "The Name of the User that caused the event.",
+          "type": "string"
+        },
+        "Status": {
+          "description": "Processing Status when event snapshot was taken.",
+          "enum": [
+            "New",
+            "InProgress",
+            "Failed",
+            "Successful",
+            "Abandoned",
+            "Retried",
+            "Deleted"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "QueueItemEventDtoStatus",
+            "modelAsString": false
+          }
+        },
+        "ReviewStatus": {
+          "description": "Review Status when event snapshot was taken.",
+          "enum": [
+            "None",
+            "InReview",
+            "Verified",
+            "Retried"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "QueueItemEventDtoReviewStatus",
+            "modelAsString": false
+          }
+        },
+        "ReviewerUserId": {
+          "format": "int64",
+          "description": "Reviewer User Id when event snapshot was taken.",
+          "type": "integer"
+        },
+        "ReviewerUserName": {
+          "description": "Reviewer User Name when event snapshot was taken.",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[QueueItemDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[QueueItemDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueueItemDto"
+          }
+        }
+      }
+    },
+    "QueueItemDto": {
+      "description": "Defines a piece of data that can be processed by a robot and the information associated with its processing status.\r\n<para />Queue items are grouped in queues.",
+      "type": "object",
+      "properties": {
+        "QueueDefinitionId": {
+          "format": "int64",
+          "description": "The Id of the parent queue.",
+          "type": "integer"
+        },
+        "QueueDefinition": {
+          "$ref": "#/definitions/QueueDefinitionDto",
+          "description": "The parent queue"
+        },
+        "ProcessingException": {
+          "$ref": "#/definitions/ProcessingExceptionDto",
+          "description": "Stores the actual processing exception, if any."
+        },
+        "SpecificContent": {
+          "description": "A collection of key value pairs containing custom data configured in the Add Queue Item activity, in UiPath Studio.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "Output": {
+          "$ref": "#/definitions/QueueItemOutput",
+          "description": "A collection of key value pairs containing custom data resulted after successful processing."
+        },
+        "OutputData": {
+          "description": "A JSON representation of the output data generated by the item's processing.",
+          "type": "string"
+        },
+        "Status": {
+          "description": "The processing state of the item.",
+          "enum": [
+            "New",
+            "InProgress",
+            "Failed",
+            "Successful",
+            "Abandoned",
+            "Retried",
+            "Deleted"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "QueueItemDtoStatus",
+            "modelAsString": false
+          }
+        },
+        "ReviewStatus": {
+          "description": "The review state of the item - applicable only for failed items.",
+          "enum": [
+            "None",
+            "InReview",
+            "Verified",
+            "Retried"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "QueueItemDtoReviewStatus",
+            "modelAsString": false
+          }
+        },
+        "ReviewerUserId": {
+          "format": "int64",
+          "description": "The UserId of the Reviewer, if any.",
+          "type": "integer"
+        },
+        "ReviewerUser": {
+          "$ref": "#/definitions/SimpleUserDto",
+          "description": "Stores the actual reviewer user, if any."
+        },
+        "Key": {
+          "format": "uuid",
+          "description": "The unique identifier of a queue item.",
+          "type": "string"
+        },
+        "Reference": {
+          "description": "An optional, user-specified value for queue item identification.",
+          "maxLength": 128,
+          "minLength": 0,
+          "type": "string"
+        },
+        "ProcessingExceptionType": {
+          "description": "The processing exception. If the item has not been processed or has been processed successfully it will be null.",
+          "enum": [
+            "ApplicationException",
+            "BusinessException"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "QueueItemDtoProcessingExceptionType",
+            "modelAsString": false
+          }
+        },
+        "DueDate": {
+          "format": "date-time",
+          "description": "The latest date and time at which the item should be processed. If empty the item can be processed at any given time.",
+          "type": "string"
+        },
+        "Priority": {
+          "description": "Sets the processing importance for a given item.",
+          "enum": [
+            "High",
+            "Normal",
+            "Low"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "QueueItemDtoPriority",
+            "modelAsString": false
+          }
+        },
+        "Robot": {
+          "$ref": "#/definitions/SimpleRobotDto",
+          "description": "The robot that has processed the item, if any."
+        },
+        "DeferDate": {
+          "format": "date-time",
+          "description": "The earliest date and time at which the item is available for processing. If empty the item can be processed as soon as possible.",
+          "type": "string"
+        },
+        "StartProcessing": {
+          "format": "date-time",
+          "description": "The date and time at which the item processing started. This is null if the item was not processed.",
+          "type": "string"
+        },
+        "EndProcessing": {
+          "format": "date-time",
+          "description": "The date and time at which the item processing ended. This is null if the item was not processed.",
+          "type": "string"
+        },
+        "SecondsInPreviousAttempts": {
+          "format": "int32",
+          "description": "The number of seconds that the last failed processing lasted.",
+          "type": "integer"
+        },
+        "AncestorId": {
+          "format": "int64",
+          "description": "The Id of an ancestor item connected to the current item.",
+          "type": "integer"
+        },
+        "RetryNumber": {
+          "format": "int32",
+          "description": "The number of times this work item has been processed.\r\n<para />This can be higher than 0 only if MaxRetried number is set and the item processing failed at least once with ApplicationException.",
+          "type": "integer"
+        },
+        "SpecificData": {
+          "description": "A JSON representation of the specific content.",
+          "type": "string"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the item was created.",
+          "type": "string"
+        },
+        "Progress": {
+          "description": "String field which is used to keep track of the business flow progress.",
+          "type": "string"
+        },
+        "RowVersion": {
+          "format": "byte",
+          "description": "Identifier used for optimistic concurrency, so Orchestrator can figure whether data is out of date or not.",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ProcessingExceptionDto": {
+      "description": "Stores information about exceptions thrown while processing failed queue items.",
+      "type": "object",
+      "properties": {
+        "Reason": {
+          "description": "The reason the processing failed.",
+          "type": "string"
+        },
+        "Details": {
+          "description": "Stores additional details about the exception.",
+          "type": "string"
+        },
+        "Type": {
+          "description": "The processing exception type, if any.",
+          "enum": [
+            "ApplicationException",
+            "BusinessException"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ProcessingExceptionDtoType",
+            "modelAsString": false
+          }
+        },
+        "AssociatedImageFilePath": {
+          "description": "A path on the robot running computer to an image file that stores relevant information about the exception - e.g. a system print screen.",
+          "type": "string"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "Time when the exception occurred",
+          "type": "string"
+        }
+      }
+    },
+    "QueueItemSpecificContent": {
+      "description": "A collection of key value pairs containing custom data associated to a queue item.",
+      "type": "object",
+      "properties": {}
+    },
+    "QueueItemOutput": {
+      "description": "A collection of key value pairs containing custom data resulted after successful processing.",
+      "type": "object",
+      "properties": {
+        "DynamicProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "SimpleUserDto": {
+      "description": "Entity derived from UserDto. Is shares all the properties of the base entity except the navigation properties.",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "The name of the person for which the user is created.",
+          "maxLength": 32,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Surname": {
+          "description": "The surname of the person for which the user is created.",
+          "maxLength": 32,
+          "minLength": 0,
+          "type": "string"
+        },
+        "UserName": {
+          "description": "The name used to login to Orchestrator.",
+          "type": "string"
+        },
+        "Domain": {
+          "description": "The domain from which the user is imported",
+          "type": "string"
+        },
+        "FullName": {
+          "description": "The full name of the person constructed with the format Name Surname.",
+          "type": "string"
+        },
+        "EmailAddress": {
+          "description": "The e-mail address associated with the user.",
+          "maxLength": 256,
+          "minLength": 0,
+          "type": "string"
+        },
+        "IsEmailConfirmed": {
+          "description": "States if the email address is valid or not.",
+          "type": "boolean"
+        },
+        "LastLoginTime": {
+          "format": "date-time",
+          "description": "The date and time when the user last logged in, or null if the user never logged in.",
+          "type": "string"
+        },
+        "IsActive": {
+          "description": "States if the user is active or not. An inactive user cannot login to Orchestrator.",
+          "type": "boolean"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the user was created.",
+          "type": "string"
+        },
+        "AuthenticationSource": {
+          "description": "The source which authenticated this user.",
+          "type": "string"
+        },
+        "Password": {
+          "description": "The password used during application login.",
+          "type": "string"
+        },
+        "UserRoles": {
+          "description": "The collection of roles associated with the user.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserRoleDto"
+          }
+        },
+        "RolesList": {
+          "description": "The collection of role names associated with the user.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "LoginProviders": {
+          "description": "The collection of entities that can authenticate the user.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OrganizationUnits": {
+          "description": "The collection of organization units associated with the user.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OrganizationUnitDto"
+          }
+        },
+        "TenantId": {
+          "format": "int32",
+          "description": "The id of the tenant owning the user.",
+          "type": "integer"
+        },
+        "TenancyName": {
+          "description": "The name of the tenant owning the user.",
+          "type": "string"
+        },
+        "TenantDisplayName": {
+          "description": "The display name of the tenant owning the user.",
+          "type": "string"
+        },
+        "Type": {
+          "description": "The user type.",
+          "enum": [
+            "User",
+            "Robot"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SimpleUserDtoType",
+            "modelAsString": false
+          }
+        },
+        "NotificationSubscription": {
+          "$ref": "#/definitions/UserNotificationSubscription",
+          "description": "User can choose which notifications does he want to receive"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "UserRoleDto": {
+      "description": "Stores information about the association between a user and a role.",
+      "type": "object",
+      "properties": {
+        "UserId": {
+          "format": "int64",
+          "description": "The Id of the associated user.",
+          "type": "integer"
+        },
+        "RoleId": {
+          "format": "int32",
+          "description": "The Id of the associated role.",
+          "type": "integer"
+        },
+        "UserName": {
+          "description": "The name of the associated user",
+          "type": "string"
+        },
+        "RoleName": {
+          "description": "The name of the associated role",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "OrganizationUnitDto": {
+      "description": "Stores information about an organization unit in Orchestrator.\r\n<para /> An orchestrator unit can be understood as a company department and it is used to group different entities.",
+      "required": [
+        "DisplayName"
+      ],
+      "type": "object",
+      "properties": {
+        "DisplayName": {
+          "description": "The name of the organization unit.",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "UserNotificationSubscription": {
+      "type": "object",
+      "properties": {
+        "Queues": {
+          "type": "boolean"
+        },
+        "Robots": {
+          "type": "boolean"
+        },
+        "Jobs": {
+          "type": "boolean"
+        },
+        "Schedules": {
+          "type": "boolean"
+        }
+      }
+    },
+    "LongVersionedEntity": {
+      "type": "object",
+      "properties": {
+        "RowVersion": {
+          "format": "byte",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "BulkOperationResponseDto[Int64]": {
+      "type": "object",
+      "properties": {
+        "Success": {
+          "type": "boolean"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "FailedItems": {
+          "type": "array",
+          "items": {
+            "format": "int64",
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "ODataQueryOptions[UserDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[UserDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserDto"
+          }
+        }
+      }
+    },
+    "UserDto": {
+      "description": "Stores information about assigned role(s) and email settings, and enables a person or a Robot to login to Orchestrator.",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "The name of the person for which the user is created.",
+          "maxLength": 32,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Surname": {
+          "description": "The surname of the person for which the user is created.",
+          "maxLength": 32,
+          "minLength": 0,
+          "type": "string"
+        },
+        "UserName": {
+          "description": "The name used to login to Orchestrator.",
+          "type": "string"
+        },
+        "Domain": {
+          "description": "The domain from which the user is imported",
+          "type": "string"
+        },
+        "FullName": {
+          "description": "The full name of the person constructed with the format Name Surname.",
+          "type": "string"
+        },
+        "EmailAddress": {
+          "description": "The e-mail address associated with the user.",
+          "maxLength": 256,
+          "minLength": 0,
+          "type": "string"
+        },
+        "IsEmailConfirmed": {
+          "description": "States if the email address is valid or not.",
+          "type": "boolean"
+        },
+        "LastLoginTime": {
+          "format": "date-time",
+          "description": "The date and time when the user last logged in, or null if the user never logged in.",
+          "type": "string"
+        },
+        "IsActive": {
+          "description": "States if the user is active or not. An inactive user cannot login to Orchestrator.",
+          "type": "boolean"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the user was created.",
+          "type": "string"
+        },
+        "AuthenticationSource": {
+          "description": "The source which authenticated this user.",
+          "type": "string"
+        },
+        "Password": {
+          "description": "The password used during application login.",
+          "type": "string"
+        },
+        "UserRoles": {
+          "description": "The collection of roles associated with the user.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserRoleDto"
+          }
+        },
+        "RolesList": {
+          "description": "The collection of role names associated with the user.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "LoginProviders": {
+          "description": "The collection of entities that can authenticate the user.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "OrganizationUnits": {
+          "description": "The collection of organization units associated with the user.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OrganizationUnitDto"
+          }
+        },
+        "TenantId": {
+          "format": "int32",
+          "description": "The id of the tenant owning the user.",
+          "type": "integer"
+        },
+        "TenancyName": {
+          "description": "The name of the tenant owning the user.",
+          "type": "string"
+        },
+        "TenantDisplayName": {
+          "description": "The display name of the tenant owning the user.",
+          "type": "string"
+        },
+        "Type": {
+          "description": "The user type.",
+          "enum": [
+            "User",
+            "Robot"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "UserDtoType",
+            "modelAsString": false
+          }
+        },
+        "NotificationSubscription": {
+          "$ref": "#/definitions/UserNotificationSubscription",
+          "description": "User can choose which notifications does he want to receive"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataResponse[List[QueueProcessingRecordDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueueProcessingRecordDto"
+          }
+        }
+      }
+    },
+    "QueueProcessingRecordDto": {
+      "description": "Stores aggregated report information about the processing status of all the items from a given queue in a specific time period.",
+      "type": "object",
+      "properties": {
+        "QueueDefinitionId": {
+          "format": "int64",
+          "description": "The Id of the queue for which the report is done.",
+          "type": "integer"
+        },
+        "UiQueueMetadata": {
+          "$ref": "#/definitions/QueueDefinitionDto",
+          "description": "The queue for which the report is done."
+        },
+        "ProcessingTime": {
+          "format": "date-time",
+          "description": "The date and time when the report is computed.",
+          "type": "string"
+        },
+        "ReportType": {
+          "description": "The aggregation period used in the report.",
+          "enum": [
+            "All",
+            "Minute",
+            "Hour",
+            "Day"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "QueueProcessingRecordDtoReportType",
+            "modelAsString": false
+          }
+        },
+        "NumberOfRemainingTransactions": {
+          "format": "int32",
+          "description": "The number of unprocessed (new) items.",
+          "type": "integer"
+        },
+        "NumberOfInProgressTransactions": {
+          "format": "int32",
+          "description": "The number of items in progress.",
+          "type": "integer"
+        },
+        "NumberOfApplicationExceptions": {
+          "format": "int32",
+          "description": "The total number of application exceptions thrown while processing queue items in the given time period.",
+          "type": "integer"
+        },
+        "NumberOfBusinessExceptions": {
+          "format": "int32",
+          "description": "The total number of business exceptions thrown while processing queue items in the given time period.",
+          "type": "integer"
+        },
+        "NumberOfSuccessfulTransactions": {
+          "format": "int32",
+          "description": "The total number of successfully processed queue items in the given time period.",
+          "type": "integer"
+        },
+        "NumberOfRetriedItems": {
+          "format": "int32",
+          "description": "The total number of processing retries occurred in the given time period.",
+          "type": "integer"
+        },
+        "ApplicationExceptionsProcessingTime": {
+          "format": "decimal",
+          "description": "The total number of seconds spent processing queue items that failed with application exception in the given time period.",
+          "type": "number"
+        },
+        "BusinessExceptionsProcessingTime": {
+          "format": "decimal",
+          "description": "The total number of seconds spent processing queue items that failed with business exception in the given time period.",
+          "type": "number"
+        },
+        "SuccessfulTransactionsProcessingTime": {
+          "format": "decimal",
+          "description": "The total number of seconds spent processing successful queue items in the given time period.",
+          "type": "number"
+        },
+        "TotalNumberOfTransactions": {
+          "format": "int32",
+          "description": "The total number of item processing transactions, both failed and successful.",
+          "type": "integer"
+        },
+        "TenantId": {
+          "format": "int32",
+          "description": "The Id of the queue tenant.",
+          "type": "integer"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[QueueProcessingStatusDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[QueueProcessingStatusDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QueueProcessingStatusDto"
+          }
+        }
+      }
+    },
+    "QueueProcessingStatusDto": {
+      "description": "Stores aggregated report information about the processing status of all the items from a given queue.",
+      "type": "object",
+      "properties": {
+        "ItemsToProcess": {
+          "format": "int32",
+          "description": "The total number of items in the queue with the status New.",
+          "type": "integer"
+        },
+        "ItemsInProgress": {
+          "format": "int32",
+          "description": "The total number of items in the queue with the status InProgress.",
+          "type": "integer"
+        },
+        "QueueDefinitionId": {
+          "format": "int64",
+          "description": "The Id of the queue for which the report is done.",
+          "type": "integer"
+        },
+        "QueueDefinitionName": {
+          "description": "The name of the queue for which the report is done.",
+          "type": "string"
+        },
+        "QueueDefinitionDescription": {
+          "description": "The description of the queue for which the report is done.",
+          "type": "string"
+        },
+        "QueueDefinitionAcceptAutomaticallyRetry": {
+          "description": "States whether the queue accepts automatic item retry or not.",
+          "type": "boolean"
+        },
+        "QueueDefinitionMaxNumberOfRetries": {
+          "format": "int32",
+          "description": "The maximum number of retries allowed for any item of the queue.",
+          "type": "integer"
+        },
+        "QueueDefinitionEnforceUniqueReference": {
+          "description": "States whether Item Reference field should be unique per Queue. Deleted and retried items are not checked against this rule.",
+          "type": "boolean"
+        },
+        "ProcessingMeanTime": {
+          "format": "decimal",
+          "description": "The average time spent processing a successful item.",
+          "type": "number"
+        },
+        "SuccessfulTransactionsNo": {
+          "format": "int32",
+          "description": "The total number of successfully processed items.",
+          "type": "integer"
+        },
+        "ApplicationExceptionsNo": {
+          "format": "int32",
+          "description": "The total number of application exceptions thrown while processing queue items.",
+          "type": "integer"
+        },
+        "BusinessExceptionsNo": {
+          "format": "int32",
+          "description": "The total number of business exceptions thrown while processing queue items.",
+          "type": "integer"
+        },
+        "SuccessfulTransactionsProcessingTime": {
+          "format": "decimal",
+          "description": "The total number of seconds spent processing successful queue items.",
+          "type": "number"
+        },
+        "ApplicationExceptionsProcessingTime": {
+          "format": "decimal",
+          "description": "The total number of seconds spent processing queue items that failed with application exception.",
+          "type": "number"
+        },
+        "BusinessExceptionsProcessingTime": {
+          "format": "decimal",
+          "description": "The total number of seconds spent processing queue items that failed with business exception.",
+          "type": "number"
+        },
+        "TotalNumberOfTransactions": {
+          "format": "int32",
+          "description": "The total number of item processing transactions, both failed and successful.",
+          "type": "integer"
+        },
+        "LastProcessed": {
+          "format": "date-time",
+          "description": "The date and time of the last item processing.",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "TransactionDataDto": {
+      "description": "Stores data sent when processing of an existing or a new item starts.",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "The name of the queue in which to search for the next item or in which to insert the item before marking it as InProgress and sending it to the robot.",
+          "type": "string"
+        },
+        "RobotIdentifier": {
+          "format": "uuid",
+          "description": "The unique key identifying the robot that sent the request.",
+          "type": "string"
+        },
+        "SpecificContent": {
+          "description": "If not null a new item will be added to the queue with this content before being moved to InProgress state and returned to the robot for processing.\r\n<para />If null the next available item in the list will be moved to InProgress state and returned to the robot for processing.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "DeferDate": {
+          "format": "date-time",
+          "description": "The earliest date and time at which the item is available for processing. If empty the item can be processed as soon as possible.",
+          "type": "string"
+        },
+        "DueDate": {
+          "format": "date-time",
+          "description": "The latest date and time at which the item should be processed. If empty the item can be processed at any given time.",
+          "type": "string"
+        },
+        "Reference": {
+          "description": "An optional, user-specified value for queue item identification.",
+          "maxLength": 128,
+          "minLength": 0,
+          "type": "string"
+        },
+        "ReferenceFilterOption": {
+          "description": "Declares the strategy used to filter the Reference value.",
+          "enum": [
+            "Equals",
+            "StartsWith"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "TransactionDataDtoReferenceFilterOption",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "QueueItemDataDto": {
+      "description": "Defines the work item content.",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "The name of the queue into which the item will be added.",
+          "type": "string"
+        },
+        "Priority": {
+          "description": "Sets the processing importance for a given item.",
+          "enum": [
+            "High",
+            "Normal",
+            "Low"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "QueueItemDataDtoPriority",
+            "modelAsString": false
+          }
+        },
+        "SpecificContent": {
+          "description": "A collection of key value pairs containing custom data configured in the Add Queue Item activity, in UiPath Studio.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "DeferDate": {
+          "format": "date-time",
+          "description": "The earliest date and time at which the item is available for processing. If empty the item can be processed as soon as possible.",
+          "type": "string"
+        },
+        "DueDate": {
+          "format": "date-time",
+          "description": "The latest date and time at which the item should be processed. If empty the item can be processed at any given time.",
+          "type": "string"
+        },
+        "Reference": {
+          "description": "An optional, user-specified value for queue item identification.",
+          "maxLength": 128,
+          "minLength": 0,
+          "type": "string"
+        }
+      }
+    },
+    "BulkOperationResponseDto[FailedQueueItemDto]": {
+      "type": "object",
+      "properties": {
+        "Success": {
+          "type": "boolean"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "FailedItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FailedQueueItemDto"
+          }
+        }
+      }
+    },
+    "FailedQueueItemDto": {
+      "description": "Stores the result of the BulkAddQueueItems operation.",
+      "type": "object",
+      "properties": {
+        "Ordinal": {
+          "format": "int32",
+          "description": "Ordinal of the item that failed.\r\nA value of null means that offending item is unknown.",
+          "type": "integer"
+        },
+        "ErrorCode": {
+          "description": "Error code.",
+          "enum": [
+            "Unknown",
+            "MultipleErrors",
+            "InvalidRequest",
+            "NameAlreadyUsed",
+            "ItemNotFound",
+            "StringProtectFailed",
+            "ItemAlreadyExists",
+            "ErrorDeleting",
+            "ErrorInserting",
+            "ErrorUpdating",
+            "ErrorSendingEmail",
+            "InvalidArgument",
+            "SqlAcquireLockFailure",
+            "LibrariesFeedInUse",
+            "HasDependentItems",
+            "ItemIsInUse",
+            "ParameterMissing",
+            "ParameterInvalid",
+            "DuplicateReference",
+            "ForbiddenOperation",
+            "InvalidUser",
+            "FeatureDisabled",
+            "OptimisticConcurrency",
+            "EncryptionException",
+            "CannotCreateOrMigrateTenantDb",
+            "TenantIsRequired",
+            "InvalidAuditRelationship",
+            "InvalidOrganizationUnit",
+            "RequiredOrganizationUnit",
+            "OrganizationUnitNotEditable",
+            "MachineAlreadyPairedWithDifferentLicenseKey",
+            "NoAvailableLicenses",
+            "HasAttachedRobots",
+            "InvalidMachineKey",
+            "MachineNameRequired",
+            "UserNameRequired",
+            "CannotDeleteBusyRobot",
+            "MachineNameCannotChange",
+            "MachineLicenseCannotChange",
+            "CannotUpdateBusyRobot",
+            "MachineTypeCannotChange",
+            "UserNameInvalid",
+            "SessionAlreadyActive",
+            "CannotAssignMachineToFloatingRobot",
+            "CannotUpdateRobotHostingType",
+            "CannotAssignMachineTemplateToStandardRobot",
+            "CannotUpdateActiveSession",
+            "MachineTemplateUniqueLicenseKey",
+            "InvalidMachineId",
+            "InvalidNonProductionMachineSlots",
+            "InvalidUnattendedMachineSlots",
+            "DisconnectedRobot",
+            "UnResponsiveRobot",
+            "UnsupportedFloatingSessionRobotType",
+            "EnvironmentDeploymentConflict",
+            "ServerConflict",
+            "ActionAlreadyPerformed",
+            "UnavailableResources",
+            "UserIsDeleted",
+            "UserIsLockedOut",
+            "ChangePassword",
+            "PasswordExpired",
+            "InvalidPassword",
+            "CannotDeleteStaticRole",
+            "UserNotEditable",
+            "DomainUnreachable",
+            "PasswordResetFailed",
+            "ConfirmEmailFailed",
+            "CannotUsePreviousPassword",
+            "RoleIsNotEditable",
+            "UserNotFoundInDomain",
+            "CannotUpdateUsername",
+            "InvalidLoginMethod",
+            "InvalidUsernameOrPassword",
+            "MultipleMatchingUsers",
+            "CannotCallFromHost",
+            "CredentialAssetEmptyPasswordForNewUser",
+            "CredentialAssetEmptyPasswordForNewRobot",
+            "AssetTypeNonUpdatable",
+            "AssetNotAvailableForRobot",
+            "InvalidCron",
+            "ScheduleWillNeverRun",
+            "ScheduleMisfired",
+            "ScheduleInvalidTimeZone",
+            "DownloadUnavailable",
+            "CannotConnectToPackagesRepository",
+            "NotSupportedByExternalFeeds",
+            "ErrorDownloading",
+            "InvalidPackageDetails",
+            "TenantFeedInUse",
+            "InvalidProcessKey",
+            "JobTypeCannotBeStopped",
+            "JobCannotBeCancelled",
+            "JobCannotBeTerminated",
+            "VersionNotFound",
+            "ProcessNotFound",
+            "HasAttachedProcesses",
+            "InvalidExtension",
+            "InvalidPackageCount",
+            "PreviousVersionNotFound",
+            "HasRunningJobs",
+            "TenantNotFound",
+            "PendingJobsAlreadyExist",
+            "InvalidStartJobRobotIds",
+            "UnregisteredCannotStartJobs",
+            "LicenseExpiredCannotStartJobs",
+            "InvalidReleaseKey",
+            "InvalidPackageVersion",
+            "TenantIsDisabled",
+            "PackageNotFound",
+            "NoRobotsAvailable",
+            "PathTooLong",
+            "JobExecutionFaulted",
+            "ErrorPackagePublish",
+            "CyberArkEditPasswordNotAllowed",
+            "LogMessageNotFound",
+            "LogRobotNameNotFound",
+            "EncryptionKeyNotFound",
+            "EncryptionKeyIncorrectFormat",
+            "AzureKeyVaultRetrieveIssue",
+            "AzureKeyVaultStoreIssue",
+            "TransactionReferenceRequired",
+            "InvalidTransactionProgressStatus",
+            "TransactionNotStarted",
+            "ReviewerNotAvailable",
+            "QueueDefinitionParametersCannotChange",
+            "QueueProcessingApplicationException",
+            "LicenseNotFound",
+            "LicenseExpired",
+            "LicenseAlreadyInUse",
+            "InvalidLicenseFormat",
+            "LicenseLimitExceeded",
+            "UnattendedLicenseLimitExceeded",
+            "NonProductionLicenseLimitExceeded",
+            "AttendedLicenseLimitExceeded",
+            "DevelopmentLicenseLimitExceeded",
+            "RobotFailedToAcquireLicense",
+            "NonProductionSlotsLimitExceeded",
+            "UnattendedSlotsLimitExceeded",
+            "LicenseUnregistered",
+            "LicenseNotAvailable",
+            "NotEnoughAvailableSlots",
+            "NotEnoughRuntimeLicenses",
+            "SlotsExceedLicenseLimit",
+            "NotEnoughAvailableLicenses",
+            "HostLicenseLimitExceeded",
+            "NoHostLicense",
+            "LicenseNewInvalidArguments",
+            "LicenseMachineDisabled",
+            "CannotDisableBusyMachine",
+            "ArgumentMetadataExtract",
+            "ArgumentMetadataValidation",
+            "ArgumentDefinitionExtract",
+            "ArgumentValueExtract",
+            "ArgumentValidation",
+            "UnknownWebhookEventType",
+            "WebhookQuotaReached",
+            "ExecutionMediaStorageUnavailable",
+            "ExecutionMediaNotAvailableForJob",
+            "ExecutionMediaContentNotAvailable",
+            "ContentLengthTooLarge"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "FailedQueueItemDtoErrorCode",
+            "modelAsString": false
+          }
+        },
+        "ErrorMessage": {
+          "description": "Error message.",
+          "type": "string"
+        }
+      }
+    },
+    "TransactionResultDto": {
+      "description": "Stores data sent when processing an item ended.",
+      "type": "object",
+      "properties": {
+        "IsSuccessful": {
+          "description": "States if the processing was successful or not.",
+          "type": "boolean"
+        },
+        "ProcessingException": {
+          "$ref": "#/definitions/ProcessingExceptionDto",
+          "description": "The details of the processing exception thrown if the item failed."
+        },
+        "DeferDate": {
+          "format": "date-time",
+          "description": "The earliest date and time at which the item is available for processing. If empty the item can be processed as soon as possible.",
+          "type": "string"
+        },
+        "DueDate": {
+          "format": "date-time",
+          "description": "The latest date and time at which the item should be processed. If empty the item can be processed at any given time.",
+          "type": "string"
+        },
+        "Output": {
+          "$ref": "#/definitions/QueueItemOutput",
+          "description": "A collection of key value pairs containing custom data resulted after successful processing."
+        },
+        "Progress": {
+          "description": "String field which is used to keep track of the business flow progress.",
+          "type": "string"
+        }
+      }
+    },
+    "ODataQueryOptions[ReleaseDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[ReleaseDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReleaseDto"
+          }
+        }
+      }
+    },
+    "ReleaseDto": {
+      "description": "A release enables the assignment of a process to an environment.",
+      "required": [
+        "ProcessKey",
+        "ProcessVersion",
+        "Name",
+        "EnvironmentId"
+      ],
+      "type": "object",
+      "properties": {
+        "Key": {
+          "description": "A unique identifier associated to each release.",
+          "type": "string"
+        },
+        "ProcessKey": {
+          "description": "The unique identifier of the process associated with the release.",
+          "type": "string"
+        },
+        "ProcessVersion": {
+          "description": "The version of the process associated with the release.",
+          "type": "string"
+        },
+        "IsLatestVersion": {
+          "description": "States whether the version of process associated with the release is latest or not.",
+          "type": "boolean"
+        },
+        "IsProcessDeleted": {
+          "description": "States whether the process associated with the release is deleted or not.",
+          "type": "boolean"
+        },
+        "Description": {
+          "description": "Used to add additional information about a release in order to better identify it.",
+          "type": "string"
+        },
+        "Name": {
+          "description": "A custom name of the release. The default name format is ProcessName_EnvironmentName.",
+          "type": "string"
+        },
+        "EnvironmentId": {
+          "format": "int64",
+          "description": "The Id of the environment associated with the release.",
+          "type": "integer"
+        },
+        "EnvironmentName": {
+          "description": "The name of the environment associated with the release.",
+          "type": "string"
+        },
+        "Environment": {
+          "$ref": "#/definitions/EnvironmentDto",
+          "description": "The environment associated with the release."
+        },
+        "InputArguments": {
+          "description": "Input parameters in JSON format to be passed as default values to job execution.",
+          "type": "string"
+        },
+        "CurrentVersion": {
+          "$ref": "#/definitions/ReleaseVersionDto",
+          "description": "The release version associated with the current release."
+        },
+        "ReleaseVersions": {
+          "description": "The collection of release versions that current release had over time.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReleaseVersionDto"
+          }
+        },
+        "Arguments": {
+          "$ref": "#/definitions/ArgumentMetadata",
+          "description": "Input/Output arguments consumed/produced by the release"
+        },
+        "ProcessSettings": {
+          "$ref": "#/definitions/ProcessSettingsDto"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[LogDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[LogDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LogDto"
+          }
+        }
+      }
+    },
+    "LogDto": {
+      "description": "Logs generated by Robots and execution reports. Can be stored in ElasticSearch and/or to a local SQL database.\r\n<para />Note: The endpoint for this type is /odata/RobotLogs URL.",
+      "type": "object",
+      "properties": {
+        "Level": {
+          "description": "Defines the log severity.",
+          "enum": [
+            "Trace",
+            "Debug",
+            "Info",
+            "Warn",
+            "Error",
+            "Fatal"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "LogDtoLevel",
+            "modelAsString": false
+          }
+        },
+        "WindowsIdentity": {
+          "description": "The name of the user that performed the action that was logged.",
+          "type": "string"
+        },
+        "ProcessName": {
+          "description": "The name of the process.",
+          "type": "string"
+        },
+        "TimeStamp": {
+          "format": "date-time",
+          "description": "The exact date and time the action was performed.",
+          "type": "string"
+        },
+        "Message": {
+          "description": "The log message. This can also be a message logged through the Log Message activity in UiPath Studio.",
+          "type": "string"
+        },
+        "JobKey": {
+          "format": "uuid",
+          "description": "The key of the job running the process that generated the log, if any.",
+          "type": "string"
+        },
+        "RawMessage": {
+          "description": "A JSON format message containing all the above fields.",
+          "type": "string"
+        },
+        "RobotName": {
+          "description": "The name of the Robot that generated the log.",
+          "type": "string"
+        },
+        "MachineId": {
+          "format": "int64",
+          "description": "The Id of the Machine on which the Robot that generated the log is running.",
+          "type": "integer"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataResponse[List[KeyValuePair[String,String]]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair[String,String]"
+          }
+        }
+      }
+    },
+    "KeyValuePair[String,String]": {
+      "type": "object",
+      "properties": {
+        "Key": {
+          "type": "string",
+          "readOnly": true
+        },
+        "Value": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "ODataResponse[List[String]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ODataQueryOptions[RoleDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[RoleDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RoleDto"
+          }
+        }
+      }
+    },
+    "RoleDto": {
+      "description": "A role acts as a grouping of permissions. Roles are associated with users to provide application authorization.",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "A custom name for the role.",
+          "type": "string"
+        },
+        "DisplayName": {
+          "description": "An alternative name used for UI display.",
+          "type": "string"
+        },
+        "Groups": {
+          "description": "Allows grouping multiple roles together.",
+          "type": "string"
+        },
+        "IsStatic": {
+          "description": "States whether this role is defined by the application and cannot be deleted or it is user defined and can be deleted.",
+          "type": "boolean"
+        },
+        "IsEditable": {
+          "description": "States whether the permissions for this role can be modified or not.",
+          "type": "boolean"
+        },
+        "Permissions": {
+          "description": "The collection of application permissions associated with the role.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionDto"
+          }
+        },
+        "Id": {
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[SessionDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[SessionDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SessionDto"
+          }
+        }
+      }
+    },
+    "SessionDto": {
+      "description": "Stores information about the last status reported to Orchestrator by a registered robot.",
+      "type": "object",
+      "properties": {
+        "Robot": {
+          "$ref": "#/definitions/RobotWithLicenseDto",
+          "description": "The Robot for which the information is stored."
+        },
+        "HostMachineName": {
+          "description": "The name of the machine a Robot is hosted on.",
+          "type": "string"
+        },
+        "MachineId": {
+          "format": "int64",
+          "description": "The Id of the Machine.",
+          "type": "integer"
+        },
+        "MachineName": {
+          "description": "The Machine's name.",
+          "type": "string"
+        },
+        "State": {
+          "description": "The value of the last reported status.",
+          "enum": [
+            "Available",
+            "Busy",
+            "Disconnected",
+            "Unknown"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SessionDtoState",
+            "modelAsString": false
+          }
+        },
+        "Job": {
+          "$ref": "#/definitions/JobDto",
+          "description": "The Job that is executed by the robot."
+        },
+        "ReportingTime": {
+          "format": "date-time",
+          "description": "The date and time when the last heartbeat came.",
+          "type": "string"
+        },
+        "Info": {
+          "description": "May store additional information about the robot state.",
+          "type": "string"
+        },
+        "IsUnresponsive": {
+          "description": "If the robot did not report status for longer than 120 seconds.",
+          "type": "boolean"
+        },
+        "LicenseErrorCode": {
+          "description": "Last licensing error status.",
+          "enum": [
+            "NoLicense",
+            "LicenseExpired",
+            "LicenseUnregistered",
+            "NoAvailableLicenses",
+            "NotEnoughAvailableSlots",
+            "NotEnoughRuntimeLicenses",
+            "LicenseIsAlreadyInUse",
+            "InvalidRequest",
+            "SlotsExceedLicenseLimit",
+            "RuntimeDisabled"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SessionDtoLicenseErrorCode",
+            "modelAsString": false
+          }
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "RobotWithLicenseDto": {
+      "description": "Entity derived from RobotDto. Is shares all the properties of the base entity and includes the license field.",
+      "required": [
+        "Name",
+        "Username",
+        "Type",
+        "HostingType"
+      ],
+      "type": "object",
+      "properties": {
+        "License": {
+          "$ref": "#/definitions/RobotLicenseDto",
+          "description": "The attached license"
+        },
+        "LicenseKey": {
+          "description": "The key is automatically generated from the server for the Robot machine.\r\n<para />For the robot to work, the same key must exist on both the robot and Orchestrator.\r\n<para />All robots on a machine must have the same license key in order to register correctly.",
+          "maxLength": 255,
+          "minLength": 0,
+          "type": "string"
+        },
+        "MachineName": {
+          "description": "The name of the machine a Robot is hosted on.",
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        },
+        "MachineId": {
+          "format": "int64",
+          "description": "The Id of the machine a Robot is hosted on",
+          "type": "integer"
+        },
+        "Name": {
+          "description": "A custom name for the robot.",
+          "maxLength": 19,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Username": {
+          "description": "The machine username. If the user is under a domain, you are required to also specify it in a DOMAIN\\username format.\r\n<para />Note: You must use short domain names, such as desktop\\administrator and NOT desktop.local/administrator.",
+          "maxLength": 100,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Description": {
+          "description": "Used to add additional information about a robot in order to better identify it.",
+          "maxLength": 500,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Version": {
+          "description": "The Robot's Version.",
+          "type": "string"
+        },
+        "Type": {
+          "description": "The Robot type.",
+          "enum": [
+            "NonProduction",
+            "Attended",
+            "Unattended",
+            "Development"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RobotWithLicenseDtoType",
+            "modelAsString": false
+          }
+        },
+        "HostingType": {
+          "description": "The Robot hosting type (Standard / Floating).",
+          "enum": [
+            "Standard",
+            "Floating"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RobotWithLicenseDtoHostingType",
+            "modelAsString": false
+          }
+        },
+        "Password": {
+          "description": "The Windows password associated with the machine username.",
+          "maxLength": 100,
+          "minLength": 0,
+          "type": "string"
+        },
+        "CredentialType": {
+          "description": "The robot credentials type (Default/ SmartCard)",
+          "enum": [
+            "Default",
+            "SmartCard"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "RobotWithLicenseDtoCredentialType",
+            "modelAsString": false
+          }
+        },
+        "Environments": {
+          "description": "The collection of environments the robot is part of.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EnvironmentDto"
+          }
+        },
+        "RobotEnvironments": {
+          "description": "The comma separated textual representation of environment names the robot is part of.",
+          "type": "string"
+        },
+        "ExecutionSettings": {
+          "description": "A collection of key value pairs containing execution settings for this robot.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "RobotLicenseDto": {
+      "description": "Entity that represents an acquired Robot license",
+      "type": "object",
+      "properties": {
+        "RobotId": {
+          "format": "int64",
+          "description": "The associated Robot's Id",
+          "type": "integer"
+        },
+        "Timestamp": {
+          "format": "date-time",
+          "description": "The date when the license was acquired",
+          "type": "string"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[SettingsDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[SettingsDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SettingsDto"
+          }
+        }
+      }
+    },
+    "SettingsDto": {
+      "description": "Used to store various predefined application configurations like time zone or account e-mail information.",
+      "required": [
+        "Name"
+      ],
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "The name of a specific setting (e.g. Abp.Net.Mail.DefaultFromAddress).",
+          "type": "string"
+        },
+        "Value": {
+          "description": "The value assigned to a specific setting (e.g. admin@mydomain.com).",
+          "type": "string"
+        },
+        "Scope": {
+          "description": "The scope of a specific setting.",
+          "enum": [
+            "Application",
+            "Tenant",
+            "User",
+            "All"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "SettingsDtoScope",
+            "modelAsString": false
+          }
+        },
+        "Id": {
+          "type": "string"
+        }
+      }
+    },
+    "ResponseDictionaryDto": {
+      "description": "Data type used to return Dictionary(string, string)",
+      "type": "object",
+      "properties": {
+        "Keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ExecutionSettingsConfiguration": {
+      "type": "object",
+      "properties": {
+        "Scope": {
+          "enum": [
+            "Global",
+            "Robot"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "ExecutionSettingsConfigurationScope",
+            "modelAsString": false
+          }
+        },
+        "Configuration": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExecutionSettingDefinition"
+          }
+        }
+      }
+    },
+    "ExecutionSettingDefinition": {
+      "type": "object",
+      "properties": {
+        "Key": {
+          "type": "string"
+        },
+        "DisplayName": {
+          "type": "string"
+        },
+        "ValueType": {
+          "type": "string"
+        },
+        "DefaultValue": {
+          "type": "string"
+        },
+        "PossibleValues": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ListResultDto[NameValueDto]": {
+      "type": "object",
+      "properties": {
+        "Items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NameValueDto"
+          }
+        }
+      }
+    },
+    "NameValueDto": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "string"
+        }
+      }
+    },
+    "CalendarDto": {
+      "type": "object",
+      "properties": {
+        "TimeZoneId": {
+          "type": "string"
+        },
+        "ExcludedDates": {
+          "type": "array",
+          "items": {
+            "format": "date-time",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ODataQueryOptions[TenantDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[TenantDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TenantDto"
+          }
+        }
+      }
+    },
+    "TenantDto": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "Name of the tenant.",
+          "maxLength": 64,
+          "minLength": 0,
+          "pattern": "^[\\p{L}][\\p{L}0-9-_]+$",
+          "type": "string"
+        },
+        "Key": {
+          "description": "Unique Key of the tenant.",
+          "type": "string"
+        },
+        "DisplayName": {
+          "description": "Display name of the the tenant",
+          "maxLength": 128,
+          "minLength": 0,
+          "type": "string"
+        },
+        "AdminEmailAddress": {
+          "description": "Default tenant's admin user account email address.",
+          "maxLength": 256,
+          "minLength": 0,
+          "type": "string"
+        },
+        "AdminName": {
+          "description": "Default tenant's admin user account name.",
+          "maxLength": 32,
+          "minLength": 0,
+          "type": "string"
+        },
+        "AdminSurname": {
+          "description": "Default tenant's admin user account surname.",
+          "maxLength": 32,
+          "minLength": 0,
+          "type": "string"
+        },
+        "AdminPassword": {
+          "description": "Default tenant's admin user account password. Only valid for create/update operations.",
+          "maxLength": 32,
+          "minLength": 0,
+          "type": "string"
+        },
+        "LastLoginTime": {
+          "format": "date-time",
+          "description": "The last time a user logged in this tenant.",
+          "type": "string"
+        },
+        "IsActive": {
+          "description": "Specifies if the tenant is active or not.",
+          "type": "boolean"
+        },
+        "AcceptedDomainsList": {
+          "description": "Accepted DNS list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "HasConnectionString": {
+          "description": "Specifies if the the tenant has a connection string defined",
+          "type": "boolean"
+        },
+        "ConnectionString": {
+          "description": "DB connection string",
+          "maxLength": 1024,
+          "minLength": 0,
+          "type": "string"
+        },
+        "License": {
+          "$ref": "#/definitions/TenantLicenseDto",
+          "description": "Licensing info."
+        },
+        "Id": {
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "TenantLicenseDto": {
+      "type": "object",
+      "properties": {
+        "HostLicenseId": {
+          "format": "int64",
+          "description": "The host license Id.",
+          "type": "integer"
+        },
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date it was uploaded.",
+          "type": "string"
+        },
+        "Code": {
+          "description": "The license code.",
+          "type": "string"
+        },
+        "Allowed": {
+          "$ref": "#/definitions/LicenseFields",
+          "description": "Contains the number of allowed licenses for each type"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "ODataQueryOptions[UserLoginAttemptDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[UserLoginAttemptDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserLoginAttemptDto"
+          }
+        }
+      }
+    },
+    "UserLoginAttemptDto": {
+      "type": "object",
+      "properties": {
+        "CreationTime": {
+          "format": "date-time",
+          "description": "The date and time when the action was performed.",
+          "type": "string"
+        },
+        "ClientIpAddress": {
+          "description": "Client IP Address",
+          "type": "string"
+        },
+        "ClientName": {
+          "description": "Client name",
+          "type": "string"
+        },
+        "BrowserInfo": {
+          "description": "Browser Information",
+          "type": "string"
+        },
+        "Result": {
+          "description": "The login's attempt result",
+          "enum": [
+            "Success",
+            "InvalidUserNameOrEmailAddress",
+            "InvalidPassword",
+            "UserIsNotActive",
+            "InvalidTenancyName",
+            "TenantIsNotActive",
+            "UserEmailIsNotConfirmed",
+            "UnknownExternalLogin",
+            "LockedOut",
+            "UserPhoneNumberIsNotConfirmed"
+          ],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "UserLoginAttemptDtoResult",
+            "modelAsString": false
+          }
+        },
+        "UserId": {
+          "format": "int64",
+          "description": "The user that authenticated",
+          "type": "integer"
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "UserPermissionsCollection": {
+      "description": "Stores information about all the permissions a user is associated with in Orchestrator.",
+      "type": "object",
+      "properties": {
+        "UserId": {
+          "format": "int64",
+          "description": "The Id of the user associated with the permissions.",
+          "type": "integer"
+        },
+        "Permissions": {
+          "description": "The collection of names of the permissions the user is associated with.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ChangePasswordDto": {
+      "description": "Encapsulates information needed to change user password",
+      "type": "object",
+      "properties": {
+        "CurrentPassword": {
+          "description": "Existing user password",
+          "type": "string"
+        },
+        "NewPassword": {
+          "description": "The new user password",
+          "type": "string"
+        }
+      }
+    },
+    "UpdateUserPasswordDto": {
+      "required": [
+        "Username"
+      ],
+      "type": "object",
+      "properties": {
+        "TenancyName": {
+          "type": "string"
+        },
+        "Username": {
+          "type": "string"
+        },
+        "CurrentPassword": {
+          "description": "Existing user password",
+          "type": "string"
+        },
+        "NewPassword": {
+          "description": "The new user password",
+          "type": "string"
+        }
+      }
+    },
+    "ODataQueryOptions[WebhookDto]": {
+      "type": "object",
+      "properties": {
+        "IfMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "IfNoneMatch": {
+          "type": "object",
+          "readOnly": true
+        },
+        "Context": {
+          "$ref": "#/definitions/ODataQueryContext",
+          "readOnly": true
+        },
+        "Request": {
+          "type": "object",
+          "readOnly": true
+        },
+        "RawValues": {
+          "$ref": "#/definitions/ODataRawQueryOptions",
+          "readOnly": true
+        },
+        "SelectExpand": {
+          "$ref": "#/definitions/SelectExpandQueryOption",
+          "readOnly": true
+        },
+        "Apply": {
+          "$ref": "#/definitions/ApplyQueryOption",
+          "readOnly": true
+        },
+        "Filter": {
+          "$ref": "#/definitions/FilterQueryOption",
+          "readOnly": true
+        },
+        "OrderBy": {
+          "$ref": "#/definitions/OrderByQueryOption",
+          "readOnly": true
+        },
+        "Skip": {
+          "$ref": "#/definitions/SkipQueryOption",
+          "readOnly": true
+        },
+        "Top": {
+          "$ref": "#/definitions/TopQueryOption",
+          "readOnly": true
+        },
+        "Count": {
+          "$ref": "#/definitions/CountQueryOption",
+          "readOnly": true
+        },
+        "Validator": {
+          "$ref": "#/definitions/ODataQueryValidator"
+        }
+      }
+    },
+    "ODataResponse[List[WebhookDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookDto"
+          }
+        }
+      }
+    },
+    "WebhookDto": {
+      "required": [
+        "Url",
+        "Enabled",
+        "SubscribeToAllEvents",
+        "AllowInsecureSsl"
+      ],
+      "type": "object",
+      "properties": {
+        "Url": {
+          "maxLength": 2000,
+          "minLength": 0,
+          "type": "string"
+        },
+        "Enabled": {
+          "type": "boolean"
+        },
+        "Secret": {
+          "maxLength": 100,
+          "minLength": 0,
+          "type": "string"
+        },
+        "SubscribeToAllEvents": {
+          "type": "boolean"
+        },
+        "AllowInsecureSsl": {
+          "type": "boolean"
+        },
+        "Events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookEventDto"
+          }
+        },
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        }
+      }
+    },
+    "WebhookEventDto": {
+      "required": [
+        "EventType"
+      ],
+      "type": "object",
+      "properties": {
+        "EventType": {
+          "maxLength": 50,
+          "minLength": 0,
+          "type": "string"
+        }
+      }
+    },
+    "ODataResponse[List[WebhookEventTypeDto]]": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/WebhookEventTypeDto"
+          }
+        }
+      }
+    },
+    "WebhookEventTypeDto": {
+      "description": "",
+      "type": "object",
+      "properties": {
+        "Name": {
+          "description": "Event type key",
+          "type": "string"
+        },
+        "Group": {
+          "description": "Group",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {},
+  "responses": {},
+  "securityDefinitions": {},
+  "security": [],
+  "tags": []
+}

--- a/UiPath.Web.Client/UiPath.Web.Client.csproj
+++ b/UiPath.Web.Client/UiPath.Web.Client.csproj
@@ -58,6 +58,7 @@
     <None Include="Swagger\UiPath2018.3.0-CE.2.swagger" />
     <None Include="Swagger\UiPath2018.4.1.swagger" />
     <None Include="Swagger\UiPath2019.1.swagger" />
+	<None Include="Swagger\UiPath2019.4.3.swagger" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime">
@@ -91,9 +92,12 @@
   <Target Name="Client20191" Inputs="Swagger\UiPath2019.1.swagger" Outputs="generated20191\UiPathWebApi.cs">
     <Exec Outputs="generated20191\UiPathWebApi.cs" Command="autorest --input-file=Swagger\UiPath2019.1.swagger --output-folder=generated20191 --csharp --csharp.namespace=UiPath.Web.Client20191 --add-credentials" />
   </Target>
-  <Target Name="GenerateUiPathSwaggerClient" BeforeTargets="CoreCompile" DependsOnTargets="Client20181;Client20182;Client20183;Client20184;Client20191">
+  <Target Name="Client20194" Inputs="Swagger\UiPath2019.4.swagger" Outputs="generated20194\UiPathWebApi.cs">
+    <Exec Outputs="generated20194\UiPathWebApi.cs" Command="autorest --input-file=Swagger\UiPath2019.4.swagger --output-folder=generated20194 --csharp --csharp.namespace=UiPath.Web.Client20194 --add-credentials" />
+  </Target>
+  <Target Name="GenerateUiPathSwaggerClient" BeforeTargets="CoreCompile" DependsOnTargets="Client20181;Client20182;Client20183;Client20184;Client20191;Client20194">
     <ItemGroup>
-      <AutoRestGenerated Include="generated20181\*.cs;generated20181\Models\*.cs;generated20182\*.cs;generated20182\Models\*.cs;generated20183\*.cs;generated20183\Models\*.cs;generated20184\*.cs;generated20184\Models\*.cs;generated20191\*.cs;generated20191\Models\*.cs" />
+      <AutoRestGenerated Include="generated20181\*.cs;generated20181\Models\*.cs;generated20182\*.cs;generated20182\Models\*.cs;generated20183\*.cs;generated20183\Models\*.cs;generated20184\*.cs;generated20184\Models\*.cs;generated20191\*.cs;generated20191\Models\*.cs;generated20194\*.cs;generated20194\Models\*.cs" />
       <Compile Include="@(AutoRestGenerated)">
         <AutoGen>True</AutoGen>
         <Visible>True</Visible>

--- a/UiPath.Web.Client/UiPathWebApi.cs
+++ b/UiPath.Web.Client/UiPathWebApi.cs
@@ -33,4 +33,11 @@ namespace UiPath.Web.Client20191
     }
 }
 
+namespace UiPath.Web.Client20194
+{
+    public partial class UiPathWebApi : Client.Generic.IUiPathWebApi
+    {
+    }
+}
+
 


### PR DESCRIPTION
**Overview**:
This PR addresses issue #61 and introduces three new cmdlets, `Edit-RobotSettings`, `Clear-RobotSettings` and `Get-RobotSettings`, through which we can retrieve, edit and clear specific robot settings.

See `RobotSettingsTests` for examples on how they are used.