### PR TITLE
[ON_HOLD] MaintenanceMode: Add tenant support

### DIFF
--- a/UiPath.PowerShell/Cmdlets/GetMaintenance.cs
+++ b/UiPath.PowerShell/Cmdlets/GetMaintenance.cs
@@ -16,12 +16,11 @@ namespace UiPath.PowerShell.Cmdlets
     /// <para type="description">SystemSchedulesFired   : 0</para>
     /// </summary>
     [Cmdlet(VerbsCommon.Get, Nouns.Maintenance)]
-    public class GetMaintenance : AuthenticatedCmdlet
-    {
+    public class GetMaintenance : MaintenanceBaseCmdlet
+    { 
         protected override void ProcessRecord()
         {
-            var result = HandleHttpOperationException(() => Api_19_10.Maintenance.Get());
-            WriteObject(MaintenanceSetting.FromDto(result));
+            WriteObject(MaintenanceSetting.FromDto(Api_19_10.Maintenance.Get(TenantId)));
         }
     }
 }

--- a/UiPath.PowerShell/Cmdlets/StartMaintenance.cs
+++ b/UiPath.PowerShell/Cmdlets/StartMaintenance.cs
@@ -1,8 +1,8 @@
 ﻿using System.Management.Automation;
+using UiPath.PowerShell.Models;
+using UiPath.PowerShell.Resources;
 using UiPath.PowerShell.Util;
 using UiPath.Web.Client201910;
-using UiPath.PowerShell.Resources;
-using UiPath.PowerShell.Models;
 
 namespace UiPath.PowerShell.Cmdlets
 {
@@ -19,7 +19,7 @@ namespace UiPath.PowerShell.Cmdlets
     /// </example>
     /// </summary>
     [Cmdlet(VerbsLifecycle.Start, Nouns.Maintenance, ConfirmImpact = ConfirmImpact.High, SupportsShouldProcess = true)]
-    public class StartMaintenance : AuthenticatedCmdlet
+    public class StartMaintenance : MaintenanceBaseCmdlet
     {
         /// <summary>
         /// <para type="description">
@@ -42,7 +42,7 @@ namespace UiPath.PowerShell.Cmdlets
 
         /// <summary>
         /// <para type="description"> 
-        /// Bypasses all API validations and forces the UiPath Orchestrator service to enter the specifed Maintenance phase.
+        /// Bypasses all API validations and forces the UiPath Orchestrator service to enter the specified Maintenance phase.
         /// </para>
         /// </summary>
         [Parameter(Mandatory = false)]
@@ -56,11 +56,11 @@ namespace UiPath.PowerShell.Cmdlets
             }
 
             var shouldKillJobs = KillJobs.IsPresent;
-            var force = Force.IsPresent; ;
+            var force = Force.IsPresent;
 
-            HandleHttpOperationException(() => Api_19_10.Maintenance.Start(Phase, force, shouldKillJobs));
+            HandleHttpOperationException(() => Api_19_10.Maintenance.Start(Phase, force, shouldKillJobs, TenantId));
 
-            WriteObject(MaintenanceSetting.FromDto(Api_19_10.Maintenance.Get()));
+            WriteObject(MaintenanceSetting.FromDto(Api_19_10.Maintenance.Get(TenantId)));
         }
     }
 }

--- a/UiPath.PowerShell/Cmdlets/StopMaintenance.cs
+++ b/UiPath.PowerShell/Cmdlets/StopMaintenance.cs
@@ -15,7 +15,7 @@ namespace UiPath.PowerShell.Cmdlets
     /// </example>
     /// </summary>
     [Cmdlet(VerbsLifecycle.Stop, Nouns.Maintenance, ConfirmImpact = ConfirmImpact.High, SupportsShouldProcess = true)]
-    public class StopMaintenance : AuthenticatedCmdlet
+    public class StopMaintenance : MaintenanceBaseCmdlet
     {
          protected override void ProcessRecord()
         {
@@ -24,9 +24,9 @@ namespace UiPath.PowerShell.Cmdlets
                 return;
             }
 
-            HandleHttpOperationException(() => Api_19_10.Maintenance.End());
+            HandleHttpOperationException(() => Api_19_10.Maintenance.End(TenantId));
 
-            WriteObject(MaintenanceSetting.FromDto(Api_19_10.Maintenance.Get()));
+            WriteObject(MaintenanceSetting.FromDto(Api_19_10.Maintenance.Get(TenantId)));
         }
     }
 }

--- a/UiPath.PowerShell/UiPath.PowerShell.csproj
+++ b/UiPath.PowerShell/UiPath.PowerShell.csproj
@@ -90,6 +90,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resource.resx</DependentUpon>
     </Compile>
+    <Compile Include="Util\MaintenanceBaseCmdlet.cs" />
     <Compile Include="Util\UiPathTypeConverter.cs" />
     <Compile Include="Util\UserCmdlet.cs" />
     <Compile Include="Util\BindingResolver.cs" />

--- a/UiPath.PowerShell/Util/MaintenanceBaseCmdlet.cs
+++ b/UiPath.PowerShell/Util/MaintenanceBaseCmdlet.cs
@@ -1,0 +1,17 @@
+﻿using System.Management.Automation;
+
+namespace UiPath.PowerShell.Util
+{
+    public abstract class MaintenanceBaseCmdlet : AuthenticatedCmdlet
+    {
+        protected const string TenantParameterSet = "Tenant";
+
+        /// <summary>
+        /// <para type="description"> 
+        /// Specified the Tenant for which the maintenance operation is performed
+        /// </para>
+        /// </summary>
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = TenantParameterSet)]
+        public int? TenantId { get; protected set; }
+    }
+}


### PR DESCRIPTION
Added a new "TenantId" parameter to maintenance mode command-lets, optional and in a different parameter set. Added a 'happy path' test for tenant maintenance. Also verified that the API doesn't receive the new parameter in the request unless specified (not null), thus guaranteeing back-compat with 19.10.

[OR-15559](https://uipath.atlassian.net/browse/OR-15559)