### PR TITLE
Rollback Newtonsoft to v.10

### DIFF
--- a/UiPath.PowerShell/UiPath.PowerShell.csproj
+++ b/UiPath.PowerShell/UiPath.PowerShell.csproj
@@ -232,7 +232,7 @@
       <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Rest.ClientRuntime">
-      <Version>2.3.18</Version>
+      <Version>2.3.20</Version>
     </PackageReference>
     <PackageReference Include="MSBuildTasks">
       <Version>1.5.0.235</Version>
@@ -240,10 +240,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.1</Version>
+      <Version>10.0.1</Version>
     </PackageReference>
     <PackageReference Include="RestSharp">
-      <Version>106.5.4</Version>
+      <Version>106.10.1</Version>
     </PackageReference>
     <PackageReference Include="System.Management.Automation.dll">
       <Version>10.0.10586</Version>

--- a/UiPath.Web.Client/UiPath.Web.Client.csproj
+++ b/UiPath.Web.Client/UiPath.Web.Client.csproj
@@ -64,7 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime">
-      <Version>2.3.18</Version>
+      <Version>2.3.20</Version>
     </PackageReference>
     <PackageReference Include="MSBuildTasks">
       <Version>1.5.0.235</Version>
@@ -72,7 +72,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.1</Version>
+      <Version>10.0.1</Version>
     </PackageReference>
     <PackageReference Include="RestSharp">
       <Version>106.5.4</Version>


### PR DESCRIPTION
Fixes #94

Long story: Az module ships with a *different* Microsoft.Rest.ClientRuntime from the one in the NuGet feed (same version and public key token, to boost). See https://github.com/Azure/azure-powershell/issues/11198