### PR TITLE
Fix #90: pass a bogus RobotName value

### DIFF
--- a/UiPath.PowerShell/Models/AssetRobotValue.cs
+++ b/UiPath.PowerShell/Models/AssetRobotValue.cs
@@ -28,6 +28,7 @@ namespace UiPath.PowerShell.Models
             return new AssetRobotValueDto
             {
                 RobotId = RobotId,
+                RobotName = "Ignore robot name require dby 19.10 bug",
                 StringValue = TextValue,
                 IntValue = IntValue,
                 BoolValue = BoolValue,


### PR DESCRIPTION
This is a workaround for OR-22396 introduced incorrect RobotAssetValue
validation in 19.10