### PR TITLE
Filter: add ExactMatch to add local filtering check

### DIFF
--- a/UiPath.PowerShell/Util/FilteredIdCmdlet.cs
+++ b/UiPath.PowerShell/Util/FilteredIdCmdlet.cs
@@ -29,9 +29,14 @@ namespace UiPath.PowerShell.Util
             }
             else
             {
-                var dtos = HandleHttpOperationException(() => getCollection(BuildFilter()));
+                var (odataFilter, localFilter) = BuildFilter<TDto>();
+                var dtos = HandleHttpOperationException(() => getCollection(odataFilter));
                 foreach(var dto in dtos)
                 {
+                    if (ExactMatch.IsPresent && !localFilter(dto))
+                    {
+                        continue;
+                    }
                     WriteObject(writer(dto));
                 }
             }

--- a/docs/Get-UiPathAsset.md
+++ b/docs/Get-UiPathAsset.md
@@ -7,8 +7,8 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathAsset [-AuthToken <AuthToken>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathAsset [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Name <string>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -24,6 +24,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathCredentialStore.md
+++ b/docs/Get-UiPathCredentialStore.md
@@ -7,14 +7,14 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathCredentialStore [-AuthToken <AuthToken>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout 
-    <int>] [-Type <string>] [<CommonParameters>]
+    Get-UiPathCredentialStore [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Name <string>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [-Type <string>] [<CommonParameters>]
     
-    Get-UiPathCredentialStore -Default <string> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout 
-    <int>] [<CommonParameters>]
+    Get-UiPathCredentialStore -Default <string> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
-    Get-UiPathCredentialStore -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathCredentialStore -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -54,6 +54,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathEnvironment.md
+++ b/docs/Get-UiPathEnvironment.md
@@ -7,11 +7,11 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathEnvironment [-AuthToken <AuthToken>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout 
-    <int>] [-Type <string>] [<CommonParameters>]
+    Get-UiPathEnvironment [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Name <string>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [-Type <string>] [<CommonParameters>]
     
-    Get-UiPathEnvironment -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathEnvironment -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -43,6 +43,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathFolder.md
+++ b/docs/Get-UiPathFolder.md
@@ -7,11 +7,11 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathFolder [-AuthToken <AuthToken>] [-DisplayName <string>] [-FullyQualifiedName <string>] [-Paging 
-    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
+    Get-UiPathFolder [-AuthToken <AuthToken>] [-DisplayName <string>] [-ExactMatch <SwitchParameter>] 
+    [-FullyQualifiedName <string>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
-    Get-UiPathFolder -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathFolder -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -43,6 +43,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathFolderUsers.md
+++ b/docs/Get-UiPathFolderUsers.md
@@ -7,11 +7,11 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathFolderUsers [-Folder] <Folder> [-AuthToken <AuthToken>] [-IncludeInherited <bool>] [-Paging 
-    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
+    Get-UiPathFolderUsers [-Folder] <Folder> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] 
+    [-IncludeInherited <bool>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
-    Get-UiPathFolderUsers -Id <long> [-AuthToken <AuthToken>] [-IncludeInherited <bool>] [-Paging <SwitchParameter>] 
-    [-RequestTimeout <int>] [<CommonParameters>]
+    Get-UiPathFolderUsers -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-IncludeInherited 
+    <bool>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -43,6 +43,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathJob.md
+++ b/docs/Get-UiPathJob.md
@@ -7,8 +7,8 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathJob -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathJob -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -24,6 +24,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathLibrary.md
+++ b/docs/Get-UiPathLibrary.md
@@ -7,8 +7,8 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathLibrary [-Authors <string>] [-AuthToken <AuthToken>] [-Id <string>] [-Paging <SwitchParameter>] 
-    [-RequestTimeout <int>] [-Title <string>] [-Version <string>] [<CommonParameters>]
+    Get-UiPathLibrary [-Authors <string>] [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Id <string>] 
+    [-Paging <SwitchParameter>] [-RequestTimeout <int>] [-Title <string>] [-Version <string>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -48,6 +48,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathLibraryVersion.md
+++ b/docs/Get-UiPathLibraryVersion.md
@@ -7,11 +7,11 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathLibraryVersion [-Id] <string> [-AuthToken <AuthToken>] [-IsLatestVersion <bool>] [-Paging 
-    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
+    Get-UiPathLibraryVersion [-Id] <string> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-IsLatestVersion 
+    <bool>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
-    Get-UiPathLibraryVersion [-Library] <Library> [-AuthToken <AuthToken>] [-IsLatestVersion <bool>] [-Paging 
-    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
+    Get-UiPathLibraryVersion [-Library] <Library> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] 
+    [-IsLatestVersion <bool>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -43,6 +43,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathMachine.md
+++ b/docs/Get-UiPathMachine.md
@@ -7,11 +7,11 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathMachine [-AuthToken <AuthToken>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [-Type <string>] [<CommonParameters>]
+    Get-UiPathMachine [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Name <string>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [-Type <string>] [<CommonParameters>]
     
-    Get-UiPathMachine -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathMachine -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -43,6 +43,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathOrganizationUnit.md
+++ b/docs/Get-UiPathOrganizationUnit.md
@@ -7,11 +7,11 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathOrganizationUnit [[-DisplayName] <string>] [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] 
-    [-RequestTimeout <int>] [<CommonParameters>]
+    Get-UiPathOrganizationUnit [[-DisplayName] <string>] [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] 
+    [-Paging <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
-    Get-UiPathOrganizationUnit -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathOrganizationUnit -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -35,6 +35,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathPackage.md
+++ b/docs/Get-UiPathPackage.md
@@ -7,9 +7,9 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathPackage [-AuthToken <AuthToken>] [-Id <string>] [-IsActive <bool>] [-IsLatestVersion <bool>] [-Key 
-    <string>] [-OldVersion <string>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [-Title <string>] [-Version 
-    <string>] [<CommonParameters>]
+    Get-UiPathPackage [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Id <string>] [-IsActive <bool>] 
+    [-IsLatestVersion <bool>] [-Key <string>] [-OldVersion <string>] [-Paging <SwitchParameter>] [-RequestTimeout 
+    <int>] [-Title <string>] [-Version <string>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -73,6 +73,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathPermission.md
+++ b/docs/Get-UiPathPermission.md
@@ -7,8 +7,8 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathPermission [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathPermission [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -16,6 +16,14 @@ DESCRIPTION
 
 PARAMETERS
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathProcess.md
+++ b/docs/Get-UiPathProcess.md
@@ -7,12 +7,12 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathProcess [-AuthToken <AuthToken>] [-Description <string>] [-EnvironmentId <long>] [-IsLatestVersion 
-    <bool>] [-IsProcessDeleted <bool>] [-Key <string>] [-Name <string>] [-Paging <SwitchParameter>] [-ProcessId 
-    <string>] [-ProcessVersion <string>] [-RequestTimeout <int>] [<CommonParameters>]
+    Get-UiPathProcess [-AuthToken <AuthToken>] [-Description <string>] [-EnvironmentId <long>] [-ExactMatch 
+    <SwitchParameter>] [-IsLatestVersion <bool>] [-IsProcessDeleted <bool>] [-Key <string>] [-Name <string>] [-Paging 
+    <SwitchParameter>] [-ProcessId <string>] [-ProcessVersion <string>] [-RequestTimeout <int>] [<CommonParameters>]
     
-    Get-UiPathProcess -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathProcess -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -92,6 +92,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathProcessSchedule.md
+++ b/docs/Get-UiPathProcessSchedule.md
@@ -7,11 +7,11 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathProcessSchedule [-AuthToken <AuthToken>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout 
-    <int>] [<CommonParameters>]
+    Get-UiPathProcessSchedule [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Name <string>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
-    Get-UiPathProcessSchedule -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathProcessSchedule -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -35,6 +35,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathQueueDefinition.md
+++ b/docs/Get-UiPathQueueDefinition.md
@@ -8,11 +8,11 @@ SYNOPSIS
     
 SYNTAX
     Get-UiPathQueueDefinition [-AcceptAutomaticallyRetry <bool>] [-AuthToken <AuthToken>] [-Description <string>] 
-    [-EnforceUniqueReference <bool>] [-MaxNumberOfRetries <int>] [-Name <string>] [-Paging <SwitchParameter>] 
-    [-RequestTimeout <int>] [<CommonParameters>]
+    [-EnforceUniqueReference <bool>] [-ExactMatch <SwitchParameter>] [-MaxNumberOfRetries <int>] [-Name <string>] 
+    [-Paging <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
-    Get-UiPathQueueDefinition -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathQueueDefinition -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -68,6 +68,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathRobot.md
+++ b/docs/Get-UiPathRobot.md
@@ -7,12 +7,12 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathRobot [-AuthToken <AuthToken>] [-HostingType <string>] [-LicenseKey <string>] [-MachineName <string>] 
-    [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [-Type <string>] [-Username <string>] 
-    [<CommonParameters>]
+    Get-UiPathRobot [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-HostingType <string>] [-LicenseKey 
+    <string>] [-MachineName <string>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [-Type 
+    <string>] [-Username <string>] [<CommonParameters>]
     
-    Get-UiPathRobot -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathRobot -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -76,6 +76,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathRobotSettings.md
+++ b/docs/Get-UiPathRobotSettings.md
@@ -7,12 +7,12 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathRobotSettings [-AuthToken <AuthToken>] [-HostingType <string>] [-LicenseKey <string>] [-MachineName 
-    <string>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [-Type <string>] [-Username 
-    <string>] [<CommonParameters>]
+    Get-UiPathRobotSettings [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-HostingType <string>] 
+    [-LicenseKey <string>] [-MachineName <string>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout 
+    <int>] [-Type <string>] [-Username <string>] [<CommonParameters>]
     
-    Get-UiPathRobotSettings -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathRobotSettings -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -76,6 +76,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathRole.md
+++ b/docs/Get-UiPathRole.md
@@ -7,8 +7,8 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathRole [-AuthToken <AuthToken>] [-DisplayName <string>] [-Name <string>] [-Paging <SwitchParameter>] 
-    [-RequestTimeout <int>] [<CommonParameters>]
+    Get-UiPathRole [-AuthToken <AuthToken>] [-DisplayName <string>] [-ExactMatch <SwitchParameter>] [-Name <string>] 
+    [-Paging <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -32,6 +32,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathSetting.md
+++ b/docs/Get-UiPathSetting.md
@@ -7,8 +7,8 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathSetting [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [-Type <string>] 
-    [<CommonParameters>]
+    Get-UiPathSetting [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [-Type <string>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -24,6 +24,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathStorageBucket.md
+++ b/docs/Get-UiPathStorageBucket.md
@@ -7,11 +7,11 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathStorageBucket [-AuthToken <AuthToken>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout 
-    <int>] [-StorageProvider <string>] [<CommonParameters>]
+    Get-UiPathStorageBucket [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Name <string>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [-StorageProvider <string>] [<CommonParameters>]
     
-    Get-UiPathStorageBucket -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathStorageBucket -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging 
+    <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -43,6 +43,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathTenant.md
+++ b/docs/Get-UiPathTenant.md
@@ -8,10 +8,11 @@ SYNOPSIS
     
 SYNTAX
     Get-UiPathTenant [-AdminEmailAddress <string>] [-AdminName <string>] [-AdminSurname <string>] [-AuthToken 
-    <AuthToken>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [<CommonParameters>]
-    
-    Get-UiPathTenant -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
+    <AuthToken>] [-ExactMatch <SwitchParameter>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
     [<CommonParameters>]
+    
+    Get-UiPathTenant -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -59,6 +60,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathUser.md
+++ b/docs/Get-UiPathUser.md
@@ -7,12 +7,13 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathUser [-AuthToken <AuthToken>] [-EmailAddress <string>] [-FullName <string>] [-IsActive <bool>] 
-    [-IsEmailConfirmed <bool>] [-Name <string>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [-Surname 
-    <string>] [-TenancyName <string>] [-Type <string>] [-UserName <string>] [<CommonParameters>]
-    
-    Get-UiPathUser -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
+    Get-UiPathUser [-AuthToken <AuthToken>] [-EmailAddress <string>] [-ExactMatch <SwitchParameter>] [-FullName 
+    <string>] [-IsActive <bool>] [-IsEmailConfirmed <bool>] [-Name <string>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [-Surname <string>] [-TenancyName <string>] [-Type <string>] [-UserName <string>] 
     [<CommonParameters>]
+    
+    Get-UiPathUser -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -100,6 +101,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named

--- a/docs/Get-UiPathWebhook.md
+++ b/docs/Get-UiPathWebhook.md
@@ -7,11 +7,11 @@ SYNOPSIS
     
     
 SYNTAX
-    Get-UiPathWebhook [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] [-Url <string>] 
-    [<CommonParameters>]
+    Get-UiPathWebhook [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [-Url <string>] [<CommonParameters>]
     
-    Get-UiPathWebhook -Id <long> [-AuthToken <AuthToken>] [-Paging <SwitchParameter>] [-RequestTimeout <int>] 
-    [<CommonParameters>]
+    Get-UiPathWebhook -Id <long> [-AuthToken <AuthToken>] [-ExactMatch <SwitchParameter>] [-Paging <SwitchParameter>] 
+    [-RequestTimeout <int>] [<CommonParameters>]
     
     
 DESCRIPTION
@@ -35,6 +35,14 @@ PARAMETERS
         Accept wildcard characters?  false
         
     -Paging <SwitchParameter>
+        
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    -ExactMatch <SwitchParameter>
         
         Required?                    false
         Position?                    named


### PR DESCRIPTION
Orchestrator breaks OData spec and considers `eq` to be `Contains`.
This fix is to add an extra check on the client that the returned dto
matches the desired filter. `-ExactMatch` parameter is required to
enable the local check.

Fixes #109