### PR TITLE
Partial fix to versioning problems

### DIFF
--- a/UiPath.PowerShell/Cmdlets/GetMachine.cs
+++ b/UiPath.PowerShell/Cmdlets/GetMachine.cs
@@ -4,8 +4,7 @@ using UiPath.PowerShell.Models;
 using UiPath.PowerShell.Util;
 using UiPath.Web.Client20182;
 using UiPath.Web.Client20183;
-using MachineDto20182 = UiPath.Web.Client20182.Models.MachineDto;
-using MachineDto20183 = UiPath.Web.Client20183.Models.MachineDto;
+using UiPath.Web.Client20204;
 using MachineDtoType = UiPath.Web.Client20183.Models.MachineDtoType;
 
 namespace UiPath.PowerShell.Cmdlets
@@ -18,13 +17,20 @@ namespace UiPath.PowerShell.Cmdlets
         public string Name { get; set; }
 
         [Filter]
-        [ValidateEnum(typeof(MachineDtoType))]
         [Parameter(ParameterSetName = "Filter")]
         public string Type { get; set; }
 
         protected override void ProcessRecord()
         {
-            if (Supports(OrchestratorProtocolVersion.V18_3))
+            if (Supports(OrchestratorProtocolVersion.V20_4))
+            {
+                ProcessImpl(
+                    (filter, top, skip) => Api_20_4.Machines.Get(filter: filter, top: top, skip: skip, count: false),
+                    id => Api_20_4.Machines.GetById(id).To<UiPath.Web.Client20204.Models.ExtendedMachineDto>(),
+                    dto => Machine.FromDto(dto));
+
+            }
+            else if (Supports(OrchestratorProtocolVersion.V18_3))
             {
                 ProcessImpl(
                     (filter, top, skip) => Api_18_3.Machines.GetMachines(filter: filter, top: top, skip: skip, count: false),

--- a/UiPath.PowerShell/Cmdlets/GetRobot.cs
+++ b/UiPath.PowerShell/Cmdlets/GetRobot.cs
@@ -3,6 +3,7 @@ using UiPath.PowerShell.Models;
 using UiPath.PowerShell.Util;
 using UiPath.Web.Client20181;
 using UiPath.Web.Client20183;
+using UiPath.Web.Client20204;
 
 namespace UiPath.PowerShell.Cmdlets
 {
@@ -25,19 +26,33 @@ namespace UiPath.PowerShell.Cmdlets
         [Parameter(ParameterSetName = "Filter")]
         public string Username { get; set; }
 
-        [ValidateEnum(typeof(Web.Client20181.Models.RobotDtoType))]
         [Filter]
         [Parameter(ParameterSetName="Filter")]
         public string Type { get; private set; }
 
-        [ValidateEnum(typeof(Web.Client20183.Models.RobotDtoHostingType))]
         [Filter]
         [Parameter(ParameterSetName = "Filter")]
         public string HostingType { get; set; }
 
         protected override void ProcessRecord()
         {
-            if (Supports(OrchestratorProtocolVersion.V18_3) || 
+            if (Supports(OrchestratorProtocolVersion.V20_4))
+            {
+                ProcessImpl(
+                   (filter, top, skip) => Api_20_4.Robots.Get(filter: filter, top: top, skip: skip, count: false),
+                    id => Api_20_4.Robots.GetById(id),
+                    dto => Robot.FromDto(dto));
+
+            }
+            else if (Supports(OrchestratorProtocolVersion.V19_10))
+            {
+                ProcessImpl(
+                   (filter, top, skip) => HandleHttpResponseException(() => Api_19_10.Robots.GetRobotsWithHttpMessagesAsync(filter: filter, top: top, skip: skip, count: false)),
+                    id => HandleHttpResponseException(() => Api_19_10.Robots.GetByIdWithHttpMessagesAsync(id)),
+                    dto => Robot.FromDto(dto));
+
+            }
+            else if (Supports(OrchestratorProtocolVersion.V18_3) || 
                 MyInvocation.BoundParameters.ContainsKey(nameof(HostingType)))
             {
                 ProcessImpl(

--- a/UiPath.PowerShell/Models/Machine.cs
+++ b/UiPath.PowerShell/Models/Machine.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.Collections;
+using System.ComponentModel;
 using UiPath.PowerShell.Util;
 using MachineDto20182 = UiPath.Web.Client20182.Models.MachineDto;
 using MachineDto20183 = UiPath.Web.Client20183.Models.MachineDto;
@@ -13,58 +15,31 @@ namespace UiPath.PowerShell.Models
         public string LicenseKey { get; private set; }
         public string Name { get; private set; }
         public int? NonProductionSlots { get; private set; }
-        public MachineDtoType? Type { get; private set; }
+        public string Type { get; private set; }
         public int? UnattendedSlots { get; private set; }
+        public Hashtable RobotVersions { get; private set; }
+        public int? TestAutomationSlots { get; private set; }
+        public int? HeadlessSlots { get; private set; }
 
-        internal static object FromDto(MachineDto20182 dto)
+        internal static object FromDto<TDto>(TDto dto) => dto.To<Machine>();
+
+        internal MachineDto20182 ToDto20182(Machine machine) => new MachineDto20182
         {
-            return new Machine
-            {
-                Id = dto.Id,
-                LicenseKey = dto.LicenseKey,
-                Name = dto.Name,
-                NonProductionSlots = dto.NonProductionSlots,
-                UnattendedSlots = dto.UnattendedSlots
-            };
-        }
+            Id = Id,
+            LicenseKey = LicenseKey,
+            Name = Name,
+            NonProductionSlots = NonProductionSlots,
+            UnattendedSlots = UnattendedSlots
+        };
 
-        internal MachineDto20182 ToDto20182(Machine machine)
+        internal MachineDto20183 ToDto20183(Machine machine) => new MachineDto20183
         {
-            return new MachineDto20182
-            {
-                Id = Id,
-                LicenseKey = LicenseKey,
-                Name = Name,
-                NonProductionSlots = NonProductionSlots,
-                UnattendedSlots = UnattendedSlots
-            };
-        }
-
-        internal MachineDto20183 ToDto20183(Machine machine)
-        {
-            return new MachineDto20183
-            {
-                Id = Id,
-                LicenseKey = LicenseKey,
-                Name = Name,
-                NonProductionSlots = NonProductionSlots,
-                Type = Type,
-                UnattendedSlots = UnattendedSlots
-            };
-        }
-
-
-        internal static object FromDto(MachineDto20183 dto)
-        {
-            return new Machine
-            {
-                Id = dto.Id,
-                LicenseKey = dto.LicenseKey,
-                Name = dto.Name,
-                NonProductionSlots = dto.NonProductionSlots,
-                UnattendedSlots = dto.UnattendedSlots,
-                Type = dto.Type
-            };
-        }
+            Id = Id,
+            LicenseKey = LicenseKey,
+            Name = Name,
+            NonProductionSlots = NonProductionSlots,
+            Type = (MachineDtoType)Enum.Parse(typeof(MachineDtoType), Type),
+            UnattendedSlots = UnattendedSlots
+        };
     }
 }

--- a/UiPath.PowerShell/Models/Robot.cs
+++ b/UiPath.PowerShell/Models/Robot.cs
@@ -6,8 +6,11 @@ using RobotDtoHostingType20183 = UiPath.Web.Client20183.Models.RobotDtoHostingTy
 using RobotDto20181 = UiPath.Web.Client20181.Models.RobotDto;
 using RobotDto20183 = UiPath.Web.Client20183.Models.RobotDto;
 using RobotDto20184 = UiPath.Web.Client20184.Models.RobotDto;
+using RobotDto201910 = UiPath.Web.Client201910.Models.RobotDto;
+using RobotDto20204 = UiPath.Web.Client20204.Models.RobotDto;
 using UiPath.PowerShell.Util;
 using System.ComponentModel;
+using System.Collections;
 
 namespace UiPath.PowerShell.Models
 {
@@ -23,31 +26,14 @@ namespace UiPath.PowerShell.Models
         public string Type { get; private set; }
         public string HostingType { get; private set; }
         public string CredentialType { get; private set; }
+        public long? CredentialStoreId { get; private set; }
+        public Hashtable ExecutionSettings { get; private set; }
+        public string ExternalName { get; private set; }
+        public string ProvisionType { get; private set; }
+        public bool? IsExternalLicensed { get; private set; }
+        public long? MachineId { get; private set; }
 
-        internal static Robot FromDto(RobotDto20181 dto)
-        {
-            return new Robot
-            {
-                Id = dto.Id.Value,
-                LicenseKey = dto.LicenseKey,
-                MachineName = dto.MachineName,
-                Name = dto.Name,
-                Description = dto.Description,
-                Username = dto.Username,
-                Type = dto.Type.ToString()
-            };
-        }
-
-        internal static Robot FromDto(RobotExecutorDto dto)
-        {
-            return new Robot
-            {
-                Id = dto.Id.Value,
-                MachineName = dto.MachineName,
-                Name = dto.Name,
-                Description = dto.Description,
-            };
-        }
+        internal static Robot FromDto<TDto>(TDto dto) => dto.To<Robot>();
 
         internal static RobotDto20181 ToDto20181(Robot robot)
         {
@@ -75,37 +61,6 @@ namespace UiPath.PowerShell.Models
                 Username = robot.Username,
                 Type = (RobotDtoType20183)Enum.Parse(typeof(RobotDtoType20183), robot.Type),
                 HostingType = (RobotDtoHostingType20183)Enum.Parse(typeof(RobotDtoHostingType20183), robot.HostingType)
-            };
-        }
-
-        internal static object FromDto(RobotDto20183 dto)
-        {
-            return new Robot
-            {
-                Id = dto.Id.Value,
-                LicenseKey = dto.LicenseKey,
-                MachineName = dto.MachineName,
-                Name = dto.Name,
-                Description = dto.Description,
-                Username = dto.Username,
-                Type = dto.Type.ToString(),
-                HostingType = dto.HostingType.ToString(),
-            };
-        }
-
-        internal static object FromDto(RobotDto20184 dto)
-        {
-            return new Robot
-            {
-                Id = dto.Id.Value,
-                LicenseKey = dto.LicenseKey,
-                MachineName = dto.MachineName,
-                Name = dto.Name,
-                Description = dto.Description,
-                Username = dto.Username,
-                Type = dto.Type.ToString(),
-                HostingType = dto.HostingType.ToString(),
-                CredentialType = dto.CredentialType.ToString()
             };
         }
     }

--- a/UiPath.PowerShell/Models/User.cs
+++ b/UiPath.PowerShell/Models/User.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using UiPath.PowerShell.Util;
-using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Models
 {
+
     [TypeConverter(typeof(UiPathTypeConverter))]
     public class User
     {
@@ -23,31 +22,19 @@ namespace UiPath.PowerShell.Models
         public IList<string> RolesList { get; private set; }
         public string Surname { get; private set; }
         public string TenancyName { get; private set; }
-        public UserDtoType? Type { get; private set; }
+        public string Type { get; private set; }
         public string UserName { get; private set; }
         public IEnumerable<int?> UserRoles { get; private set; }
+        public string ProvisionType { get; private set; }
+        public bool? MayHavePersonalWorkspace { get; private set; }
+        public bool? MayHaveRobotSession { get; private set; }
+        public bool? MayHaveUserSession { get; private set; }
+        public bool? MayHaveUnattendedSession { get; private set; }
+        public string LicenseType { get; private set; }
+        public bool? BypassBasicAuthRestriction { get; private set; }
+        public string Domain { get; private set; }
+        public bool? IsExternalLicensed { get; private set; }
 
-        internal static User FromDto(UserDto dto)
-        {
-            return new User
-            {
-                AuthenticationSource = dto.AuthenticationSource,
-                CreationTime = dto.CreationTime,
-                EmailAddress = dto.EmailAddress,
-                FullName = dto.FullName,
-                Id = dto.Id.Value,
-                IsActive = dto.IsActive,
-                IsEmailConfirmed = dto.IsEmailConfirmed,
-                LastLoginTime = dto.LastLoginTime,
-                LoginProviders = dto.LoginProviders,
-                Name = dto.Name,
-                RolesList = dto.RolesList,
-                Surname = dto.Surname,
-                TenancyName = dto.TenancyName,
-                Type = dto.Type,
-                UserName = dto.UserName,
-                UserRoles = dto.UserRoles?.Select(r => r.RoleId)
-            };
-        }
+        internal static User FromDto<TDto>(TDto dto) => dto.To<User>();
     }
 }

--- a/UiPath.PowerShell/Util/AuthenticatedCmdlet.cs
+++ b/UiPath.PowerShell/Util/AuthenticatedCmdlet.cs
@@ -73,7 +73,7 @@ namespace UiPath.PowerShell.Util
             }
         }
 
-        protected bool Supports(Version minVersion)
+        internal bool Supports(Version minVersion)
         {
             return Supports(minVersion, InternalAuthToken);
         }

--- a/UiPath.PowerShell/Util/AutoMapper.cs
+++ b/UiPath.PowerShell/Util/AutoMapper.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+
+namespace UiPath.PowerShell.Util
+{
+    internal static class AutoMapper
+    {
+        internal static TMapped To<TMapped>(this object from) where TMapped: new()
+        {
+            var mapped = new TMapped();
+
+            var map = from.GetType().GetProperties()
+                .Join(
+                    typeof(TMapped).GetProperties(),
+                    pf => pf.Name,
+                    pt => pt.Name,
+                    (pf, pt) => new { From = pf, To = pt });
+
+            foreach(var p in map)
+            {
+                var fromType = Nullable.GetUnderlyingType(p.From.PropertyType) ?? p.From.PropertyType;
+                var toType = Nullable.GetUnderlyingType(p.To.PropertyType) ?? p.To.PropertyType;
+
+                if (toType.IsEnum)
+                {
+                    var s = p.From.GetValue(from)?.ToString();
+                    if (s != null)
+                    {
+                        var e = Enum.Parse(toType, s);
+                        p.To.SetValue(mapped, e);
+                    }
+                }
+                else if (fromType.IsEnum && toType.IsAssignableFrom(typeof(string)))
+                {
+                    var s = p.From.GetValue(from)?.ToString();
+                    p.To.SetValue(mapped, s);
+                }
+                else if (fromType.IsAssignableFrom(toType))
+                {
+                    var v = p.From.GetValue(from);
+                    p.To.SetValue(mapped, v);
+                }
+            }
+
+            return mapped;
+        }
+    }
+}

--- a/UiPath.PowerShell/Util/CmdletExtensions.cs
+++ b/UiPath.PowerShell/Util/CmdletExtensions.cs
@@ -1,10 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Microsoft.Rest;
+using System;
 using System.Linq;
 using System.Management.Automation;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
+using UiPathWebApi_18_4 = UiPath.Web.Client20184.UiPathWebApi;
+using UiPathWebApi_19_10 = UiPath.Web.Client201910.UiPathWebApi;
+using UiPathWebApi_20_4 = UiPath.Web.Client20204.UiPathWebApi;
 
 namespace UiPath.PowerShell.Util
 {

--- a/UiPath.PowerShell/Util/EnumExtensions.cs
+++ b/UiPath.PowerShell/Util/EnumExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace UiPath.PowerShell.Util
+{
+    public static class EnumExtensions
+    {
+        public static TEnum Cast<TEnum>(this Enum val) where TEnum : struct
+        {
+            if (Enum.TryParse<TEnum>(val.ToString(), out var result))
+            {
+                return result;
+            }
+
+            throw new Exception($"Cannot cast value {val} ({val.GetType().Name}) to type {typeof(TEnum).Name}");
+        }
+    }
+}

--- a/UiPath.PowerShell/Util/HashtableExtensions.cs
+++ b/UiPath.PowerShell/Util/HashtableExtensions.cs
@@ -5,7 +5,7 @@ using UiPath.Web.Client20181.Models;
 
 namespace UiPath.PowerShell.Util
 {
-    internal static class HashtableExtenssions
+    internal static class HashtableExtensions
     {
         public static List<CustomKeyValuePair> ToKeyList(this Hashtable ht)
         {
@@ -15,5 +15,7 @@ namespace UiPath.PowerShell.Util
                 Value = de.Value.ToString()
             }).ToList();
         }
+
+        public static Hashtable ToHashtable<TKey, TValue>(this IDictionary<TKey, TValue> dict) => new Hashtable((IDictionary)dict);
     }
 }

--- a/UiPath.PowerShell/Util/OrchestratorProtocolVersion.cs
+++ b/UiPath.PowerShell/Util/OrchestratorProtocolVersion.cs
@@ -13,5 +13,7 @@ namespace UiPath.PowerShell.Util
         internal static Version V18_4 => Version.Parse("7.0");
 
         internal static Version V19_10 => Version.Parse("9.0");
+
+        internal static Version V20_4 => Version.Parse("11.0");
     }
 }

--- a/UiPath.PowerShell/Util/UiPathCmdlet.cs
+++ b/UiPath.PowerShell/Util/UiPathCmdlet.cs
@@ -96,6 +96,20 @@ namespace UiPath.PowerShell.Util
                 }
                 return response.Body;
             });
+
+        internal void HandleHttpResponseException(Func<Task<HttpOperationResponse>> action) => HandleHttpOperationException(() =>
+        {
+            var task = action();
+            var response = task.Result;
+            if (!response.Response.IsSuccessStatusCode)
+            {
+                var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", response.Response.StatusCode));
+                ex.Request = new HttpRequestMessageWrapper(response.Request, response.Request?.Content?.AsString() ?? string.Empty);
+                ex.Response = new HttpResponseMessageWrapper(response.Response, response.Response?.Content?.AsString() ?? string.Empty);
+                throw ex;
+            }
+        });
+
         protected T HandleHttpOperationException<T>(Func<T> action)
         {
             try

--- a/UiPath.Web.Client/Extensions/ODataExtensions.cs
+++ b/UiPath.Web.Client/Extensions/ODataExtensions.cs
@@ -116,6 +116,16 @@ namespace UiPath.Web.Client201910.Models
     {
 
     }
+
+    public partial  class ODataResponseListUserDto : IODataValues<UserDto>
+    {
+
+    }
+
+    public partial class ODataResponseListRobotDto : IODataValues<RobotDto>
+    {
+
+    }
 }
 
 namespace UiPath.Web.Client20204.Models
@@ -125,5 +135,18 @@ namespace UiPath.Web.Client20204.Models
 
     }
 
+    public partial class ODataValueIEnumerableUserDto : IODataValues<UserDto>
+    {
 
+    }
+
+    public partial class ODataValueIEnumerableRobotDto : IODataValues<RobotDto>
+    {
+
+    }
+
+    public partial class ODataValueIEnumerableExtendedMachineDto : IODataValues<ExtendedMachineDto>
+    {
+
+    }
 }


### PR DESCRIPTION
The cmdlets use the 18.1 API by default, and few use a some newer APIs,
but they do not use the right API for the right server. This leads to
serialization issues like #112 or #125 when newer Orchestrator responds
with new values for old enums and the deserialization fails.

This should unblock GetMachine, GetUser and getRobot on UiPath Platform
(API v11 (20.4)) but a more thorough solution is needed long term to
have each API call be routed through the API client that the server
expects.

Fixes #112
Fixes #125